### PR TITLE
Hide overlay during fullscreen

### DIFF
--- a/src/injection.js
+++ b/src/injection.js
@@ -661,7 +661,25 @@ function renderLearningContent() {
     const getPanelStyle = (collapsed) => `pointer-events: auto; padding: ${collapsed ? "10px 14px" : "clamp(16px, 3vw, 22px)"}; min-width: ${collapsed ? "140px" : "260px"}; max-width: ${collapsed ? "180px" : "320px"}; background: rgba(15, 23, 42, 0.96); color: #f8fafc; border-radius: ${collapsed ? "12px" : "18px"}; box-shadow: 0 24px 45px rgba(15, 23, 42, 0.45); font-family: 'Inter', 'Segoe UI', sans-serif; display: flex; flex-direction: column; gap: ${collapsed ? "6px" : "12px"}; cursor: grab; position: relative; font-size: 14px; transition: all 0.3s ease;`;
 
     function updateOverlayVisibility() {
-      overlay.style.display = isFullScreen() ? "none" : "flex";
+      if (isFullScreen()) {
+        // Store current position before hiding
+        panel.dataset.savedLeft = panel.style.left || '';
+        panel.dataset.savedRight = panel.style.right || '';
+        panel.dataset.savedTop = panel.style.top || '';
+        panel.dataset.savedBottom = panel.style.bottom || '';
+        overlay.style.display = "none";
+      } else {
+        overlay.style.display = "flex";
+        // Restore saved position after showing
+        requestAnimationFrame(() => {
+          if (panel.dataset.savedLeft !== undefined) {
+            panel.style.left = panel.dataset.savedLeft;
+            panel.style.right = panel.dataset.savedRight;
+            panel.style.top = panel.dataset.savedTop;
+            panel.style.bottom = panel.dataset.savedBottom;
+          }
+        });
+      }
     }
 
     // Listeners for fullscreen


### PR DESCRIPTION
Detect and respond to fullscreen mode to hide the learning overlay. 
- Adds an isFullScreen() helper, updateOverlayVisibility(), and registers fullscreenchange listeners (including webkit/moz/MS variants). 
- Adds an initial check to set the overlay visibility. 
- Removes fullscreenchange listeners during cleanup to avoid memory leaks.