### PR TITLE
Different style transition for dragging

### DIFF
--- a/src/injection.js
+++ b/src/injection.js
@@ -190,6 +190,9 @@ const makeDraggable = (element) => {
     dragState.startX = event.clientX;
     dragState.startY = event.clientY;
     
+    // This temporarily "mutes" the 0.3s from getPanelStyle
+    element.style.transition = 'all 0.1s ease-out'
+
     element.style.cursor = "grabbing";
     element.setPointerCapture(event.pointerId);
     event.preventDefault();
@@ -217,6 +220,9 @@ const makeDraggable = (element) => {
     if (!dragState.dragging) return;
     
     dragState.dragging = false;
+    // Dragging is over, 0.3s transition can be re-enabled for snap animation
+    element.style.transition = 'all 0.3s ease';
+
     element.style.cursor = "grab";
     
     // Snap to nearest corner when drag ends


### PR DESCRIPTION
This pull request makes an adjustment to the drag-and-drop behavior in the `makeDraggable` function. The change temporarily speeds up the transition effect while dragging, then restores the original transition for the snap animation after dragging ends. This results in a smoother and more responsive user experience during drag operations.

* During drag start, the transition style of the draggable element is set to `'all 0.1s ease-out'` to reduce lag and make the movement feel more immediate.
* When dragging ends, the transition style is reset to `'all 0.3s ease'` to provide a smooth snap animation to the nearest corner.

Before:
![SlowDrag GIF](https://github.com/user-attachments/assets/57b7a530-b791-4d4f-83b0-2ecd4c141fb2)

After:
![DraggingFaster GIF](https://github.com/user-attachments/assets/92066319-0d85-44ec-8a8c-61afaf2a6e5f)
