### PR TITLE
Feature/sematic versioning

### DIFF
--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - bsc_development_main
   workflow_dispatch:
 
 permissions:
@@ -87,6 +86,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Changelog generation from full git history
 
       - name: Download signed extension artifact
         uses: actions/download-artifact@v4
@@ -107,15 +108,16 @@ jobs:
             --exclude "node_modules/*" \
             --exclude "release-assets/*"
 
-      - name: Create draft release and upload asset
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release create "draft-${{ github.run_number }}" \
-            release-assets/*.xpi \
-            release-assets/aiki3-chrome.zip \
-            release-assets/source-code.zip \
-            --target "${{ github.sha }}" \
-            --title "Signed extension draft ${{ github.run_number }}" \
-            --notes "Automated draft release from ${{ github.ref_name }}" \
-            --draft
+      - name: Create draft release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: draft-${{ github.run_number }}
+          name: Signed extension draft ${{ github.run_number }}
+          generate_release_notes: true
+          draft: true
+          target_commitish: ${{ github.sha }}
+          files: |
+            release-assets/*.xpi
+            release-assets/aiki3-chrome.zip
+            release-assets/source-code.zip
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "svelte-app",
-  "version": "1.0.0",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "svelte-app",
-      "version": "1.0.0",
+      "version": "1.2.3",
       "dependencies": {
         "@fortawesome/free-solid-svg-icons": "^5.15.3",
         "chart.js": "^3.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "svelte-app",
-  "version": "1.2.3",
+  "name": "aiki3",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "svelte-app",
-      "version": "1.2.3",
+      "name": "aiki3",
+      "version": "3.0.0",
       "dependencies": {
         "@fortawesome/free-solid-svg-icons": "^5.15.3",
         "chart.js": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-app",
-  "version": "1.0.0",
+  "version": "1.2.3",
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-app",
-  "version": "1.2.3",
+  "version": "3.0.0",
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "svelte-app",
+  "name": "aiki3",
   "version": "3.0.0",
   "scripts": {
     "build": "rollup -c",

--- a/public/manifest.chrome.json
+++ b/public/manifest.chrome.json
@@ -2,7 +2,6 @@
   "manifest_version": 3,
   "name": "Aiki³",
   "description": "Aiki³ browser extension",
-  "version": "3.0.0",
   "icons": {
     "128": "images/AikiLogo.png"
   },

--- a/public/manifest.firefox.json
+++ b/public/manifest.firefox.json
@@ -2,7 +2,6 @@
   "manifest_version": 3,
   "name": "Aiki³",
   "description": "Aiki³ browser extension",
-  "version": "3.0.1",
   "browser_specific_settings": {
     "gecko": {
       "id": "aiki3@extension.local",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,19 +2,17 @@
   "manifest_version": 3,
   "name": "Aiki³",
   "description": "Aiki³ browser extension",
-  "version": "3.0.1",
-  "browser_specific_settings": {
-    "gecko": {
-      "id": "aiki3@extension.local",
-      "strict_min_version": "109.0"
-    }
-  },
   "icons": {
     "128": "images/AikiLogo.png"
   },
-  "permissions": ["storage", "tabs", "webNavigation"],
+  "permissions": [
+    "storage",
+    "tabs",
+    "windows",
+    "webNavigation"
+  ],
   "background": {
-    "scripts": ["build/background.js"]
+    "service_worker": "build/background.js"
   },
   "action": {
     "default_title": "Aiki",
@@ -23,19 +21,28 @@
   },
   "content_scripts": [
     {
-      "matches": ["<all_urls>"],
-      "js": ["build/injection.js"],
+      "matches": [
+        "<all_urls>"
+      ],
+      "js": [
+        "build/injection.js"
+      ],
       "run_at": "document_start"
     }
   ],
   "web_accessible_resources": [
     {
-      "resources": ["images/AikiLogo.png"],
-      "matches": ["<all_urls>"]
+      "resources": [
+        "images/AikiLogo.png"
+      ],
+      "matches": [
+        "<all_urls>"
+      ]
     }
   ],
   "content_security_policy": {
     "extension_pages": "script-src 'self'; object-src 'self';"
   },
-  "options_page": "index.html?page=settings"
+  "options_page": "index.html?page=settings",
+  "version": "1.2.3"
 }

--- a/scripts/buildChrome.js
+++ b/scripts/buildChrome.js
@@ -8,14 +8,19 @@ const path = require('path');
 const publicDir = path.join(__dirname, '..', 'public');
 const chromeManifest = path.join(publicDir, 'manifest.chrome.json');
 const targetManifest = path.join(publicDir, 'manifest.json');
+const version = require('../package.json').version;
 
-// Restore Chrome manifest if backup exists
 if (fs.existsSync(chromeManifest)) {
     fs.copyFileSync(chromeManifest, targetManifest);
     console.log('✓ Restored Chrome manifest to manifest.json');
 } else {
-    // No backup exists, assume current manifest.json is already Chrome
     console.log('✓ Chrome manifest already in place');
 }
 
+const manifest = JSON.parse(fs.readFileSync(targetManifest, 'utf8'));
+manifest.version = version;
+
+fs.writeFileSync(targetManifest, JSON.stringify(manifest, null, 2));
+
+console.log(`✓ Injected version ${version}`);
 console.log('✓ Ready for Chrome build');

--- a/scripts/buildFirefox.js
+++ b/scripts/buildFirefox.js
@@ -9,8 +9,8 @@ const publicDir = path.join(__dirname, '..', 'public');
 const firefoxManifest = path.join(publicDir, 'manifest.firefox.json');
 const targetManifest = path.join(publicDir, 'manifest.json');
 const chromeManifest = path.join(publicDir, 'manifest.chrome.json');
+const version = require('../package.json').version;
 
-// Backup original Chrome manifest if not already backed up
 if (!fs.existsSync(chromeManifest)) {
     if (fs.existsSync(targetManifest)) {
         fs.copyFileSync(targetManifest, chromeManifest);
@@ -18,7 +18,6 @@ if (!fs.existsSync(chromeManifest)) {
     }
 }
 
-// Copy Firefox manifest to manifest.json
 if (fs.existsSync(firefoxManifest)) {
     fs.copyFileSync(firefoxManifest, targetManifest);
     console.log('✓ Copied Firefox manifest to manifest.json');
@@ -27,4 +26,10 @@ if (fs.existsSync(firefoxManifest)) {
     process.exit(1);
 }
 
+const manifest = JSON.parse(fs.readFileSync(targetManifest, 'utf8'));
+manifest.version = version;
+
+fs.writeFileSync(targetManifest, JSON.stringify(manifest, null, 2));
+
+console.log(`✓ Injected version ${version}`);
 console.log('✓ Ready for Firefox build');

--- a/scripts/bump-dev-version.js
+++ b/scripts/bump-dev-version.js
@@ -1,6 +1,11 @@
 const fs = require('fs');
-const manifest = require('../public/manifest.json');
+
+const version = require('../package.json').version;
+const manifest = JSON.parse(fs.readFileSync('./public/manifest.json', 'utf8'));
+
 const now = Math.floor(Date.now() / 10000);
-const base = manifest.version.split('.').slice(0, 3).join('.');
+const base = version.split('.').slice(0, 3).join('.');
 manifest.version = `${base}.${now}`;
+
 fs.writeFileSync('./public/manifest.json', JSON.stringify(manifest, null, 2));
+console.log(`Bumped dev version to ${manifest.version}`);


### PR DESCRIPTION
## Overview
- Unified version source: `package.json` is now the single source of truth for the extension version.
- Removed hardcoded version from manifest files.
- Build scripts now inject the version into `manifest.json` at build time.
- Switched draft release creation to `softprops/action-gh-release` with auto-generated release notes.
- Removed old releases from Github and all releases from Mozilla Developer Hub, to start from scratch with versioning.
- This is tested by creating a manual release, which creates a version on Firefox Developer Hub, and creates a release for the Chrome and Firefox extension (which works).

## Version management refactor
- Removed hardcoded `"version"` fields from `manifest.json`, `manifest.chrome.json` and `manifest.firefox.json`.
- `buildChrome.js` and `buildFirefox.js` now read the version from `package.json` and inject it into `manifest.json` before building.
- `bump-dev-version.js` now also reads the base version from `package.json` instead of `manifest.json`.
- Renamed package from `svelte-app` to `aiki3` and bumped to `3.0.0` in `package.json` and `package-lock.json`.

## CI/CD improvements
- Replaced the manual `gh release create` shell command with the `softprops/action-gh-release@v2` action.
- Release notes are now auto-generated from commit history (`generate_release_notes: true`), by fetching full git history (`fetch-depth: 0`) during checkout.
- Removed `bsc_development_main` from the list of branches that trigger the sign workflow.

## Manifest cleanup
- `manifest.json` is now the base/Chrome manifest. Firefox-specific fields (`browser_specific_settings`) have been moved exclusively to `manifest.firefox.json`.