### PR TITLE
new initial version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiki3",
-  "version": "3.0.0",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiki3",
-      "version": "3.0.0",
+      "version": "3.2.0",
       "dependencies": {
         "@fortawesome/free-solid-svg-icons": "^5.15.3",
         "chart.js": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiki3",
-  "version": "3.0.0",
+  "version": "3.2.0",
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",


### PR DESCRIPTION
This fixes the error described below:
## Årsag
Firefox tracker hvis der bliver fjernet en gammel version som har været registreret i deres system. Hvis version 1.2.3 har været uploadet og derefter fjernet, så vil man ikke længere uden problemer kunne køre og uploade extensionen med version 1.2.3 hverken i lokal- eller produktionsmiljø.

## Løsning
Der er intet andet at gøre end at bump til en nyere version. Måske man kan ændre noget på dev kontoen i Mozilla.