### PR TITLE
Inject API base URL from .env via Rollup replace

### DIFF
--- a/docs/setting-up-env
+++ b/docs/setting-up-env
@@ -1,0 +1,4 @@
+## 0 - Create .env file in root directory
+
+## 1 - Insert value:
+``PUBLIC_API_BASE_URL=http://localhost:3000/api/env``

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
       "devDependencies": {
         "@rollup/plugin-commonjs": "^17.0.0",
         "@rollup/plugin-node-resolve": "^11.0.0",
+        "@rollup/plugin-replace": "^6.0.3",
         "cross-env": "^10.1.0",
         "dotenv": "^16.0.0",
         "dotenv-cli": "^11.0.0",
@@ -618,6 +619,81 @@
         "rollup": "^1.20.0||^2.0.0"
       }
     },
+    "node_modules/@rollup/plugin-replace": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-6.0.3.tgz",
+      "integrity": "sha512-J4RZarRvQAm5IF0/LwUUg+obsm+xZhYnbMXmXROyoSE1ATJe3oXSb9L5MMppdxP2ylNSjv6zFBwKYjcKMucVfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "magic-string": "^0.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-replace/node_modules/@rollup/pluginutils": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-replace/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/plugin-replace/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@rollup/plugin-replace/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
@@ -718,6 +794,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1907,6 +1984,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4112,6 +4190,7 @@
       "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -4652,6 +4731,7 @@
       "integrity": "sha512-vzSyuGr3eEoAtT/A6bmajosJZIUWySzY2CzB3w2pgPvnkUjGqlDnsNnA0PMO+mMAhuyMul6C2uuZzY6ELSkzyA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 8"
       }

--- a/package.json
+++ b/package.json
@@ -14,9 +14,10 @@
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.0.0",
-    "dotenv": "^16.0.0",
     "@rollup/plugin-node-resolve": "^11.0.0",
+    "@rollup/plugin-replace": "^6.0.3",
     "cross-env": "^10.1.0",
+    "dotenv": "^16.0.0",
     "dotenv-cli": "^11.0.0",
     "rollup": "^2.3.4",
     "rollup-plugin-css-only": "^3.1.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -78,12 +78,6 @@ export default [
       // If we're building for production (npm run build
       // instead of npm run dev), minify
       production && terser(),
-      replace({
-        preventAssignment: true,
-        values: {
-          __API_BASE_URL__: JSON.stringify(env.PUBLIC_API_BASE_URL || 'http://localhost:3000'), //Fallback value if .env is undefined
-        }
-      }),
     ],
     watch: {
       clearScreen: false,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,10 +3,14 @@ import commonjs from "@rollup/plugin-commonjs";
 import resolve from "@rollup/plugin-node-resolve";
 import { terser } from "rollup-plugin-terser";
 import css from "rollup-plugin-css-only";
+import replace from '@rollup/plugin-replace';
+import dotenv from 'dotenv';
 
 const production = !process.env.ROLLUP_WATCH;
 // Live reload is not compatible with extension pages (CSP + file scheme)
 const enableLiveReload = false;
+const env = dotenv.config().parsed || {};
+
 
 function serve() {
   let server;
@@ -74,6 +78,12 @@ export default [
       // If we're building for production (npm run build
       // instead of npm run dev), minify
       production && terser(),
+      replace({
+        preventAssignment: true,
+        values: {
+          __API_BASE_URL__: JSON.stringify(env.PUBLIC_API_BASE_URL || 'http://localhost:3000'), //Fallback value if .env is undefined
+        }
+      }),
     ],
     watch: {
       clearScreen: false,
@@ -86,7 +96,16 @@ export default [
       format: "iife",
       file: "public/build/background.js",
     },
-    plugins: [resolve(), commonjs()],
+    plugins: [
+      resolve(), 
+      commonjs(),
+      replace({
+        preventAssignment: true,
+        values: {
+          __API_BASE_URL__: JSON.stringify(env.PUBLIC_API_BASE_URL || 'http://localhost:3000/api/'), //Fallback value if .env is undefined
+        }
+      }),
+    ],
     watch: {
       clearScreen: false,
     },

--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -10,8 +10,8 @@ The background script will then call the appropriate function from this apiServi
 
 import storage from "../util/storage";
 
-const API_BASE_URL = "http://localhost:3000/api/"; // This is the base URL for the backend server. Adjust as needed.
-
+// This is the base URL for the backend server. 
+const API_BASE_URL = __API_BASE_URL__; // Rollup replace will insert the actual value from env at __API_BASE_URL__
 
 /**
  * Returns: { ok: boolean, message: string, data: any }


### PR DESCRIPTION
This pull request introduces environment variable support for configuring the backend API base URL. The main changes include updating the build configuration to inject environment variables, adding documentation for setup, and modifying the API service to use the injected variable.

**Environment Variable Injection and Build Configuration:**

* Added `@rollup/plugin-replace` to `package.json` and updated `rollup.config.js` to load environment variables from a `.env` file using `dotenv`, injecting `PUBLIC_API_BASE_URL` into the build as `__API_BASE_URL__` with a fallback value.

**Documentation:**

* Added setup instructions in `docs/setting-up-env` for creating a `.env` file and specifying `PUBLIC_API_BASE_URL`.

**Code Usage:**

* Updated `src/services/apiService.js` to use the injected `__API_BASE_URL__` constant instead of a hardcoded URL. 
* @rollup/plugin-replace + dotenv to inject PUBLIC_API_BASE_URL at build time. 
* rollup.config.js imports dotenv and plugin-replace and configures replacements (with fallbacks) for instances of __API_BASE_URL__. 
* package.json updated to include @rollup/plugin-replace as a devDependency. 
* Added docs/setting-up-env with instructions.