### PR TITLE
Adding Invite Codes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -794,7 +794,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1984,7 +1983,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4190,7 +4188,6 @@
       "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -4731,7 +4728,6 @@
       "integrity": "sha512-vzSyuGr3eEoAtT/A6bmajosJZIUWySzY2CzB3w2pgPvnkUjGqlDnsNnA0PMO+mMAhuyMul6C2uuZzY6ELSkzyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 8"
       }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,17 +2,24 @@
   "manifest_version": 3,
   "name": "Aiki³",
   "description": "Aiki³ browser extension",
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "aiki3@extension.local",
+      "strict_min_version": "109.0"
+    }
+  },
   "icons": {
     "128": "images/AikiLogo.png"
   },
   "permissions": [
     "storage",
     "tabs",
-    "windows",
     "webNavigation"
   ],
   "background": {
-    "service_worker": "build/background.js"
+    "scripts": [
+      "build/background.js"
+    ]
   },
   "action": {
     "default_title": "Aiki",
@@ -44,5 +51,5 @@
     "extension_pages": "script-src 'self'; object-src 'self';"
   },
   "options_page": "index.html?page=settings",
-  "version": "1.2.3"
+  "version": "3.2.0"
 }

--- a/src/Pages/Components/Settings/InviteCodeSettings.svelte
+++ b/src/Pages/Components/Settings/InviteCodeSettings.svelte
@@ -5,19 +5,28 @@
   import { MESSAGE_API_UPDATE_INVITE_CODE } from "../../../values/messageTypeValues";
 
   let inviteCode = "";
+  let savedInviteCode = "";
 
   onMount(async () => {
     inviteCode = (await storage.inviteCode.get()) ?? "";
+    savedInviteCode = inviteCode;
   });
 
   async function saveInviteCode() {
-    storage.inviteCode.set(inviteCode);
     try {
       const result = await browser.runtime.sendMessage({
         type: MESSAGE_API_UPDATE_INVITE_CODE,
         inviteCode,
       });
       const ok = result?.ok;
+
+      if (ok) {
+        storage.inviteCode.set(inviteCode);
+        savedInviteCode = inviteCode; // update the saved value on success
+      } else {
+        inviteCode = savedInviteCode; // revert the input
+      }
+
       alertStore.add({
         type: ok ? "success" : "error",
         message: ok
@@ -26,6 +35,7 @@
       });
     } catch (error) {
       console.error("Error updating invite code:", error);
+      inviteCode = savedInviteCode; // revert the input on error too
       alertStore.add({
         type: "warning",
         message: "Failed to update to the server. Please try again.",

--- a/src/Pages/Components/Settings/InviteCodeSettings.svelte
+++ b/src/Pages/Components/Settings/InviteCodeSettings.svelte
@@ -1,0 +1,69 @@
+<script>
+  import { onMount } from "svelte";
+  import storage from "../../../util/storage";
+  import { alertStore } from "../../../services/alertService";
+  import { MESSAGE_API_UPDATE_INVITE_CODE } from "../../../values/messageTypeValues";
+
+  let inviteCode = "";
+
+  onMount(async () => {
+    inviteCode = (await storage.inviteCode.get()) ?? "";
+  });
+
+  async function saveInviteCode() {
+    storage.inviteCode.set(inviteCode);
+    try {
+      const result = await browser.runtime.sendMessage({
+        type: MESSAGE_API_UPDATE_INVITE_CODE,
+        inviteCode,
+      });
+      const ok = result?.ok;
+      alertStore.add({
+        type: ok ? "success" : "error",
+        message: ok
+          ? "Invite code updated successfully."
+          : `${result?.message || "Failed to update to the server. Please try again."}`,
+      });
+    } catch (error) {
+      console.error("Error updating invite code:", error);
+      alertStore.add({
+        type: "warning",
+        message: "Failed to update to the server. Please try again.",
+      });
+    }
+  }
+</script>
+
+<h5>Invite Code:</h5>
+
+<div class="row">
+  <div class="col-sm">
+    <p>Enter your invite code:</p>
+  </div>
+  <div class="col-sm" />
+  <div class="col-sm">
+    <input
+      type="text"
+      bind:value={inviteCode}
+      on:blur={saveInviteCode}
+      on:keypress={(e) => {
+        if (e.key === "Enter") e.target.blur();
+      }}
+      class="form-control form-control-sm"
+      placeholder="Enter invite code"
+    />
+  </div>
+</div>
+
+<style>
+  p {
+    padding: 0;
+    margin-bottom: 1.5rem;
+    font-family: var(--fontContent);
+    font-size: var(--fontSizeSettings);
+  }
+
+  h5 {
+    font-family: var(--fontHeaders);
+  }
+</style>

--- a/src/Pages/Components/Settings/SetRedirection.svelte
+++ b/src/Pages/Components/Settings/SetRedirection.svelte
@@ -13,6 +13,7 @@
   import Container from "./Container.svelte";
   import ThemeSelector from "./ThemeSelector.svelte";
   import OperatingHoursSettings from "./OperatingHoursSettings.svelte";
+  import InviteCodeSettings from "./InviteCodeSettings.svelte";
   import TimeSettings from "./TimeSettings.svelte";
 
   export let user = "";
@@ -151,7 +152,8 @@
   <TimeSettings {user} />
   <hr />
   <OperatingHoursSettings {user} />
-
+  <hr />
+  <InviteCodeSettings />
   <hr />
   <h5>Other Settings:</h5>
   <div>

--- a/src/Pages/Components/Settings/SetUser.svelte
+++ b/src/Pages/Components/Settings/SetUser.svelte
@@ -22,6 +22,7 @@
   let authMode = "login";
   let password = "";
   let confirmPassword = "";
+  let inviteCode = "";
   let isSubmitting = false;
   const basicEmailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   const dispatch = createEventDispatcher();
@@ -37,6 +38,7 @@
     }
     password = "";
     confirmPassword = "";
+    inviteCode = "";
   }
   
   function isValidEmail(value) {
@@ -71,13 +73,14 @@
     userIsRegistered = false;
   }
 
-  async function authenticateWithBackend({ mode, email, plainTextPassword }) {
+  async function authenticateWithBackend({ mode, email, plainTextPassword, inviteCode }) {
    const type = mode === "register" ? MESSAGE_API_REGISTER : MESSAGE_API_LOGIN;
    try {
      const result = await browser.runtime.sendMessage({
         type,
         email,
         password: plainTextPassword,
+        ...(mode === "register" && inviteCode ? { inviteCode } : {}) // Only include inviteCode if we're in register mode and it's provided
       });
      if (!result || !result.ok) {
        return { ok: false, message: result?.message || "Server error. Please try again.", token: null };
@@ -142,6 +145,7 @@
         mode: authMode,
         email: normalizedUser,
         plainTextPassword: password,
+        inviteCode
       });
 
       if (!authResult?.ok) {
@@ -234,6 +238,14 @@
             placeholder="Re-enter your password..."
             autocomplete="new-password"
           />
+
+          <input
+            bind:value={inviteCode}
+            type="text"
+            class="form-control auth-input"
+            placeholder="Enter your invite code (optional)..."
+          />
+
         {/if}
 
         <button class="btn btn-primary submit-button" type="submit" disabled={isSubmitting}>

--- a/src/Pages/Components/Settings/SetUser.svelte
+++ b/src/Pages/Components/Settings/SetUser.svelte
@@ -69,6 +69,7 @@
   async function clearSessionLocally() {
     await storage.jwt.set("");
     await storage.uid.set("");
+    await storage.inviteCode.set("");
     user = "";
     userIsRegistered = false;
   }

--- a/src/handlers/apiHandler.js
+++ b/src/handlers/apiHandler.js
@@ -9,7 +9,8 @@ import {
   MESSAGE_API_UPDATE_OPERATING_HOURS_END,
   MESSAGE_API_UPDATE_SESSION_DURATION,
   MESSAGE_API_UPDATE_REWARD_TIME,
-  MESSAGE_API_UPDATE_LEARNING_TIME
+  MESSAGE_API_UPDATE_LEARNING_TIME,
+  MESSAGE_API_UPDATE_INVITE_CODE
 } from "../values/messageTypeValues";
 function toTokenResult(result) {
   if (!result.ok) {
@@ -47,6 +48,11 @@ export async function handleApiMessage(message) {
           return { ok: false, message: result.message, data: null};
         }
         return { ok: true, data: result};
+  }
+
+  if (message.type === MESSAGE_API_UPDATE_INVITE_CODE) {
+    const result = await updateUserSettings({ inviteCode: message.inviteCode });
+    return { ok: result.ok, message: result.message };
   }
 
   if (message.type === MESSAGE_API_UPDATE_OPERATING_HOURS_START) {

--- a/src/handlers/apiHandler.js
+++ b/src/handlers/apiHandler.js
@@ -38,7 +38,7 @@ export async function handleApiMessage(message) {
   }
 
   if (message.type === MESSAGE_API_REGISTER) {
-    const result = await registerUser({ email: message.email, password: message.password });
+    const result = await registerUser({ email: message.email, password: message.password, inviteCode: message.inviteCode });
     return toTokenResult(result);
   }
 

--- a/src/services/alertService.js
+++ b/src/services/alertService.js
@@ -35,7 +35,7 @@ function createAlertStore() {
         // Push the new alert to the store
         update(alerts => {
             // Ensure that no more than 2 alerts are displayed at once
-            if (alerts.length >= 2 ) {
+            if (alerts.length >= 5 ) {
                 alerts = alerts.slice(1);
             }
 

--- a/src/services/alertService.js
+++ b/src/services/alertService.js
@@ -35,7 +35,7 @@ function createAlertStore() {
         // Push the new alert to the store
         update(alerts => {
             // Ensure that no more than 2 alerts are displayed at once
-            if (alerts.length >= 5 ) {
+            if (alerts.length >= 3 ) {
                 alerts = alerts.slice(1);
             }
 

--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -35,7 +35,7 @@ async function apiCall(endpoint, method, data = null, token = null) {
     const response_json = await response.json();
 
     if (!response.ok) {
-      return { ok: false, message: response_json?.message ?? response.statusText };
+      return { ok: false, message: response_json?.message ?? response_json?.error ?? response.statusText };
     }
     return { ok: true, message: "", ...response_json };
   } catch (error) {

--- a/src/services/settingsService.js
+++ b/src/services/settingsService.js
@@ -9,7 +9,7 @@ async function syncDBSettingsToLocalStorage(db) {
     }
     
     await Promise.all([
-        storage.inviteCode.set(db.inviteCode.code),
+        storage.inviteCode.set(db.inviteCode?.code),
         storage.timeSettings.sessionMinutes.set(db.sessionDurationMinutes),
         storage.timeSettings.rewardMinutes.set(db.rewardTimeMinutes),
         storage.timeSettings.learningTime.set({ min: db.dailyLearningGoalMinutes, sec: 0}),

--- a/src/services/settingsService.js
+++ b/src/services/settingsService.js
@@ -4,7 +4,7 @@ import { MESSAGE_API_GET_USER_SETTINGS } from "../values/messageTypeValues";
 import { alertStore } from "../services/alertService";
 
 async function syncDBSettingsToLocalStorage(db) {
-    if (!db.inviteCode?.isActive) {
+    if (db.inviteCode && !db.inviteCode?.isActive) {
         alertStore.add({ message: "Your invite code is no longer active", type: "warning" });
     }
     

--- a/src/services/settingsService.js
+++ b/src/services/settingsService.js
@@ -1,9 +1,15 @@
 import browser from "webextension-polyfill";
 import storage from "../util/storage";
 import { MESSAGE_API_GET_USER_SETTINGS } from "../values/messageTypeValues";
+import { alertStore } from "../services/alertService";
 
 async function syncDBSettingsToLocalStorage(db) {
+    if (!db.inviteCode?.isActive) {
+        alertStore.add({ message: "Your invite code is no longer active", type: "warning" });
+    }
+    
     await Promise.all([
+        storage.inviteCode.set(db.inviteCode.code),
         storage.timeSettings.sessionMinutes.set(db.sessionDurationMinutes),
         storage.timeSettings.rewardMinutes.set(db.rewardTimeMinutes),
         storage.timeSettings.learningTime.set({ min: db.dailyLearningGoalMinutes, sec: 0}),

--- a/src/util/storage.js
+++ b/src/util/storage.js
@@ -139,6 +139,15 @@ async function getJwt() {
   return result.jwt || "";
 }
 
+function setInviteCode(inviteCode) {
+  storage.set({ inviteCode: inviteCode ?? "" });
+}
+
+async function getInviteCode() {
+  const result = await storage.get("inviteCode");
+  return result.inviteCode || "";
+}
+
 /**
  * @function
  * @param {object} origin
@@ -632,6 +641,7 @@ export default {
   list: { set: setList, get: getList }, // this is list of time-wasting sites defined by the user
   uid: { set: setUid, get: getUid },
   jwt: { set: setJwt, get: getJwt },
+  inviteCode: { get: getInviteCode, set: setInviteCode },
   redirection: { toggle: toggleRedirection, get: getRedirectionToggled },
   stats: {
     storeSession: storeSession,

--- a/src/values/messageTypeValues.js
+++ b/src/values/messageTypeValues.js
@@ -7,6 +7,7 @@ export const MESSAGE_API_REGISTER = "api:register"
 
 export const MESSAGE_API_GET_USER_SETTINGS = "api:getUserSettings"
 
+export const MESSAGE_API_UPDATE_INVITE_CODE = "api:updateInviteCode"
 export const MESSAGE_API_UPDATE_OPERATING_HOURS_START = "api:updateOperatingHoursStart"
 export const MESSAGE_API_UPDATE_OPERATING_HOURS_END = "api:updateOperatingHoursEnd"
 export const MESSAGE_API_UPDATE_SESSION_DURATION = "api:updateSessionDuration"


### PR DESCRIPTION
# Overview
Adds invite code support into storage, settings UI, registration and sign-out flow.
Invite codes are persisted in local storage, optionally passed during registration, and cleared on sign-out.
Users are warned via an alert if their invite code is no longer active when settings are synced from the backend.

# Visuals
<img width="400" src="https://github.com/user-attachments/assets/48f882ff-e15a-48f0-b70a-ba955f96e949" />

# Error handling edge cases
- Users cannot sign up with a non existing invite code.
- Users cannot sign up with a inactive invite code.
- Users with a invite code which has been active, but is now inactive, will get an alert until they remove/change their inactive invite code.
- If a user tries to change to their invite code, it will first check the database. If the result is 'ok', it will update localstorage; otherwise it will revert to the ealier invite code and not update the local storage.

# Changelogs
## Invite code in local storage
- Added `getInviteCode` and `setInviteCode` functions in the `storage` utility.
- Invite code is cleared from local storage on sign-out.

## Invite code settings UI
- Created `InviteCodeSettings.svelte`, which is a new settings component that loads the stored invite code on mount and saves it to both local storage and the backend on blur.
- Added `InviteCodeSettings` to the settings page between operating hours and other settings.

## Registration flow
- Added an optional invite code input field to the register form in `SetUser.svelte`.
- Invite code is passed through `authenticateWithBackend` and included in the `MESSAGE_API_REGISTER` message only when in register mode and a value is provided.

## API handler
- Added `MESSAGE_API_UPDATE_INVITE_CODE` message type constant and handler in `apiHandler.js` that calls `updateUserSettings` with the provided invite code.
- Improved error fallback in `apiService.js` to also check `response_json?.error` when constructing error messages.

## Settings sync
- Adds a warning alert if the synced invite code is inactive.
- `syncDBSettingsToLocalStorage` now persists the invite code from the DB response.

## Alert cap
- Raised the max simultaneous alert cap from 2 to 5 to accommodate invite code warnings alongside other alerts.