### PR TITLE
Update/time wasting sites backend add remove

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,17 +2,24 @@
   "manifest_version": 3,
   "name": "Aiki³",
   "description": "Aiki³ browser extension",
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "aiki3@extension.local",
+      "strict_min_version": "109.0"
+    }
+  },
   "icons": {
     "128": "images/AikiLogo.png"
   },
   "permissions": [
     "storage",
     "tabs",
-    "windows",
     "webNavigation"
   ],
   "background": {
-    "service_worker": "build/background.js"
+    "scripts": [
+      "build/background.js"
+    ]
   },
   "action": {
     "default_title": "Aiki",
@@ -44,5 +51,5 @@
     "extension_pages": "script-src 'self'; object-src 'self';"
   },
   "options_page": "index.html?page=settings",
-  "version": "1.2.3"
+  "version": "3.2.0"
 }

--- a/src/Pages/Components/Settings/SetTimeWastingSites.svelte
+++ b/src/Pages/Components/Settings/SetTimeWastingSites.svelte
@@ -12,9 +12,12 @@
     faGlobe,
     faKeyboard,
     faTimes,
-    faPlusCircle
+    faPlusCircle,
+
   } from "@fortawesome/free-solid-svg-icons";
-  import { alertStore } from '../../../services/alertService'; 
+  import { alertStore } from '../../../services/alertService';
+  import browser from "webextension-polyfill";
+  import { MESSAGE_API_UPDATE_TIME_WASTING_SITE } from "../../../values/messageTypeValues";
 
   export let port;
   $: list = [];
@@ -114,6 +117,18 @@
         type: 'success',
         message: 'New Website Added!',
       })
+
+      const result = await browser.runtime.sendMessage({
+        type: MESSAGE_API_UPDATE_TIME_WASTING_SITE,
+        site: site
+      })
+
+      if (!result?.ok) {
+        alertStore.add({
+          type: 'warning',
+          message: "Could not reach the server"
+        });
+      }
     }
   }
 

--- a/src/Pages/Components/Settings/SetTimeWastingSites.svelte
+++ b/src/Pages/Components/Settings/SetTimeWastingSites.svelte
@@ -25,7 +25,8 @@
   export let port;
   $: list = [];
 
-  let learningUri = ""; 
+  let learningUri = "";
+  const wwwPattern = /^www\./i; 
 
   async function setup() {
     const storedList = (await storage.list.get()) || [];
@@ -104,6 +105,14 @@
       alertStore.add({
         type: 'warning',
         message: 'Input cannot be empty!',
+      })
+      return;
+    }
+
+    if (!wwwPattern.test(addItemValue)) {
+      alertStore.add({
+        type: 'warning',
+        message: 'Website must start with "www." (e.g., www.youtube.com)',
       })
       return;
     }

--- a/src/Pages/Components/Settings/SetTimeWastingSites.svelte
+++ b/src/Pages/Components/Settings/SetTimeWastingSites.svelte
@@ -26,7 +26,6 @@
   $: list = [];
 
   let learningUri = "";
-  const wwwPattern = /^www\./i; 
 
   async function setup() {
     const storedList = (await storage.list.get()) || [];
@@ -109,13 +108,23 @@
       return;
     }
 
-    if (!wwwPattern.test(addItemValue)) {
+    // Used to normalize input to always be www.domain.tld
+    let rawInput = addItemValue.trim();
+    rawInput = new URL(rawInput.startsWith("http") ? rawInput : `https://${rawInput}`).hostname ?? rawInput;
+
+    const urlPattern = /(?:https?:\/\/)?(?:www\.)?([a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.[a-zA-Z]{2,})(?:[/?#].*)?$/;
+    const match = rawInput.match(urlPattern);
+
+    if (!match) {
       alertStore.add({
         type: 'warning',
-        message: 'Website must start with "www." (e.g., www.youtube.com)',
+        message: 'Invalid URL format!',
       })
       return;
     }
+
+    // The site that has been normalized, now becomes "www.x.x" and stored in addItemvalue
+    addItemValue = `www.${match[1]}`;
 
     learningUri = parseUrl(await storage.learningUri.get())
     let site = parseUrl(addItemValue);

--- a/src/Pages/Components/Settings/SetTimeWastingSites.svelte
+++ b/src/Pages/Components/Settings/SetTimeWastingSites.svelte
@@ -17,7 +17,10 @@
   } from "@fortawesome/free-solid-svg-icons";
   import { alertStore } from '../../../services/alertService';
   import browser from "webextension-polyfill";
-  import { MESSAGE_API_UPDATE_TIME_WASTING_SITE } from "../../../values/messageTypeValues";
+  import { 
+    MESSAGE_API_UPDATE_TIME_WASTING_SITE, 
+    MESSAGE_API_REMOVE_TIME_WASTING_SITE 
+  } from "../../../values/messageTypeValues";
 
   export let port;
   $: list = [];
@@ -64,16 +67,36 @@
   ];
 
   async function removeItem(index) {
+    const domain = list[index].host;
+
     let newList = [...list];
     newList.splice(index, 1);
     list = newList;
     storage.list.set(list);
-    port.postMessage(`Update: list`);
 
     alertStore.add({
         type: 'success',
         message: 'Website removed!',
       })
+
+    try {
+      const result = await browser.runtime.sendMessage({
+        type: MESSAGE_API_REMOVE_TIME_WASTING_SITE,
+        domain: domain
+      });
+      console.log("result:", result);
+    } catch(e) {
+      console.error("sendMessage failed:", e);
+    }
+
+    port.postMessage(`Update: list`);
+
+    if (!result?.ok) {
+      alertStore.add({
+        type: 'warning',
+        message: "Could not reach the server"
+      });
+    }
   }
 
   async function addItem() {

--- a/src/Pages/Settings.svelte
+++ b/src/Pages/Settings.svelte
@@ -78,9 +78,11 @@
       <div class="container">
         <AikiDescription {user} {port} />
       </div>
-      <div class="container">
-        <SetWebsites {user} {port} />
-      </div>
+      {#key settingsKey}
+        <div class="container">
+          <SetWebsites {user} {port} />
+        </div>
+      {/key}
       {#key settingsKey} <!-- increments after a successful sync. Forcing this block to remount to re-read local storage values (thus showing correct values on the page)-->
         <div class="container">
           <SetRedirection {user} />

--- a/src/handlers/apiHandler.js
+++ b/src/handlers/apiHandler.js
@@ -9,7 +9,8 @@ import {
   MESSAGE_API_UPDATE_OPERATING_HOURS_END,
   MESSAGE_API_UPDATE_SESSION_DURATION,
   MESSAGE_API_UPDATE_REWARD_TIME,
-  MESSAGE_API_UPDATE_LEARNING_TIME
+  MESSAGE_API_UPDATE_LEARNING_TIME,
+  MESSAGE_API_UPDATE_TIME_WASTING_SITE
 } from "../values/messageTypeValues";
 function toTokenResult(result) {
   if (!result.ok) {
@@ -75,4 +76,11 @@ export async function handleApiMessage(message) {
     const result = await updateUserSettings( { dailyLearningGoalMinutes: message.learningTimeMinutes });
     return { ok: result.ok, message: result.message };
   }
+
+  if (message.type === MESSAGE_API_UPDATE_TIME_WASTING_SITE) {
+    const result = await updateUserSettings({ timeWastingSite: message.site.host });
+    return { ok: result.ok, message: result.message };
+  }
+
+
 }

--- a/src/handlers/apiHandler.js
+++ b/src/handlers/apiHandler.js
@@ -1,4 +1,4 @@
-import { loginUser, registerUser, updateUserSettings, getUserSettings } from "../services/apiService";
+import { loginUser, registerUser, updateUserSettings, getUserSettings, deleteTimeWastingSite } from "../services/apiService";
 import { fetchAndSyncSettings } from "../services/settingsService";
 import { REWARD_TIME_MINUTES } from "../values/defaultSettingValues";
 import { 
@@ -10,7 +10,8 @@ import {
   MESSAGE_API_UPDATE_SESSION_DURATION,
   MESSAGE_API_UPDATE_REWARD_TIME,
   MESSAGE_API_UPDATE_LEARNING_TIME,
-  MESSAGE_API_UPDATE_TIME_WASTING_SITE
+  MESSAGE_API_UPDATE_TIME_WASTING_SITE,
+  MESSAGE_API_REMOVE_TIME_WASTING_SITE
 } from "../values/messageTypeValues";
 function toTokenResult(result) {
   if (!result.ok) {
@@ -82,5 +83,8 @@ export async function handleApiMessage(message) {
     return { ok: result.ok, message: result.message };
   }
 
-
+  if (message.type === MESSAGE_API_REMOVE_TIME_WASTING_SITE) {
+    const result = await deleteTimeWastingSite(message.domain);
+    return { ok: result.ok, message: result.message };
+  }
 }

--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -63,3 +63,7 @@ export async function getUserSettings() {
 export async function updateUserSettings(patch) {
   return await authApiCall("users/settings", "PATCH", patch);
 }
+
+export async function deleteTimeWastingSite(domain) {
+  return await authApiCall(`users/settings/time-wasting-sites/${domain}`, "DELETE", {});
+}

--- a/src/services/settingsService.js
+++ b/src/services/settingsService.js
@@ -1,6 +1,7 @@
 import browser from "webextension-polyfill";
 import storage from "../util/storage";
 import { MESSAGE_API_GET_USER_SETTINGS } from "../values/messageTypeValues";
+import { parseUrl } from "../util/utilities";
 
 async function syncDBSettingsToLocalStorage(db) {
     await Promise.all([
@@ -9,6 +10,7 @@ async function syncDBSettingsToLocalStorage(db) {
         storage.timeSettings.learningTime.set({ min: db.dailyLearningGoalMinutes, sec: 0}),
         storage.operatingHours.from.set({ hrs: Math.floor(db.operatingStartMinutes / 60), min: db.operatingStartMinutes % 60 }),
         storage.operatingHours.to.set({ hrs: Math.floor(db.operatingEndMinutes / 60), min: db.operatingEndMinutes % 60 }),
+        storage.list.set((db.timeWastingSites || []).map(domain => parseUrl(domain))), // Stores time-wasting sites into local storage
     ])
 }
 

--- a/src/values/messageTypeValues.js
+++ b/src/values/messageTypeValues.js
@@ -13,3 +13,5 @@ export const MESSAGE_API_UPDATE_SESSION_DURATION = "api:updateSessionDuration"
 export const MESSAGE_API_UPDATE_REWARD_TIME = "api:updateRewardTime"
 export const MESSAGE_API_UPDATE_LEARNING_TIME = "api:updateLearningTime"
 export const MESSAGE_API_UPDATE_TIME_WASTING_SITE = "api:addTimeWastingSite"
+
+export const MESSAGE_API_REMOVE_TIME_WASTING_SITE = "api:removeTimeWastingSite"

--- a/src/values/messageTypeValues.js
+++ b/src/values/messageTypeValues.js
@@ -12,3 +12,4 @@ export const MESSAGE_API_UPDATE_OPERATING_HOURS_END = "api:updateOperatingHoursE
 export const MESSAGE_API_UPDATE_SESSION_DURATION = "api:updateSessionDuration"
 export const MESSAGE_API_UPDATE_REWARD_TIME = "api:updateRewardTime"
 export const MESSAGE_API_UPDATE_LEARNING_TIME = "api:updateLearningTime"
+export const MESSAGE_API_UPDATE_TIME_WASTING_SITE = "api:addTimeWastingSite"


### PR DESCRIPTION
## Overview

This PR improves how time-wasting sites are managed such that they alongside being stored in local storage, now is also stored in the backend

The key areas of improvement are:

- More robust backend communication
- Updated extension configuration and packaging
- More reliable UI state updates

## Backend Communication & Site Management
- Introduced new message types and handlers for adding/removing time-wasting sites
- Enabled frontend → backend synchronization via API calls
- Added user warnings when the backend is unreachable
- Ensured local storage stays in sync with the database, including proper domain parsing

This PR reuses the logic already used for getting settings data to synchronize backend with local storage, by simply just extending it to also include time wasting sites.

Also extends the logic for refreshing the settings page, to now also include time wasting sites