### PR TITLE
Remove Statistics component from Settings

### DIFF
--- a/src/Pages/Settings.svelte
+++ b/src/Pages/Settings.svelte
@@ -86,9 +86,6 @@
           <SetRedirection {user} />
         </div>
       {/key}
-      <div class="container">
-        <Statistics />
-      </div>
     {/if}
   </main>
   <Footer />


### PR DESCRIPTION
The statistics component is legacy, and is not currently functional.

Deleted the <div class="container"><Statistics /></div> block from Settings.svelte, removing the embedded Statistics section.