### PR TITLE
Bug/fix fault lock engage

### DIFF
--- a/src/injection.js
+++ b/src/injection.js
@@ -643,7 +643,6 @@ function renderRedirectPrompt(originUrl) {
     overlay.cleanup = () => {
       if (done) return;
       done = true;
-      resolve({ action: "continue" });
       if (hostWatchInterval) {
         clearInterval(hostWatchInterval);
         hostWatchInterval = null;

--- a/src/redirection.js
+++ b/src/redirection.js
@@ -5,6 +5,7 @@ import { parseUrl, makeDate, parseTime } from "./util/utilities";
 import SessionService from "./services/SessionService";
 import NavigationGuards from "./services/NavigationGuards";
 import PromptCoordinator from "./services/PromptCoordinator";
+import { PROMPT_SUPPRESS_DURATION } from "../src/values/defaultSettingValues"
 
 const l = console.log;
 
@@ -24,7 +25,6 @@ const strategy = {
 };
 
 let shouldShowWelcome = true;
-const PROMPT_SUPPRESS_DURATION = 10 * 60 * 1000; // 10 minutes - global cooldown across all tabs
 const PREPROMPT_ID = "__aiki-preprompt";
 
 function buildProcrastinationUrlFilters(list = []) {
@@ -233,7 +233,7 @@ async function redirect(details) {
             return; // We are in global cooldown period - Don't show prompt
           }
 
-          // Experimental variant: show consent prompt
+          // show consent prompt
           promptRedirect(details.tabId, learningUri, details.url);
         }
       }
@@ -441,8 +441,9 @@ async function checkActiveTab() {
         );
         if (handled) return;
 
-        // EXPERIMENTAL VARIANT: Show redirect prompt
+        // Show redirect prompt
         promptRedirect(tab.id, learningUri, tab.url);
+        console.log("Prompt called from checkActiveTab()") // FLAG for further research, as i do not think this is ever called
       }
     }
   } catch (error) {
@@ -659,6 +660,7 @@ async function promptRedirect(tabId, url, originUrl) {
       await storage.globalPromptLock.set({  
         timestamp: Date.now(),
       });
+      console.log("Lock engaged");
 
       // Start tracking procastination session
       navigationGuards.install();

--- a/src/services/PromptCoordinator.js
+++ b/src/services/PromptCoordinator.js
@@ -10,33 +10,34 @@ class PromptCoordinator {
     this.boundRenderContentBlocker = this.renderContentBlocker.bind(this);
   }
 
-  async promptRedirect(tabId, learningUrl, originUrl, callbacks = {}, attempt = 0) {
-    const { onAccept, onContinue } = callbacks;
+  async sendMesssageWithRetry(tabId, message, attempt = 0,) {
+    try {
+      const result = await browser.tabs.sendMessage(tabId, message);
+      console.log("Retrying message" + message);
 
-    // Validate tab still exists and is on the intended time wasting site before retrying
-    if (attempt > 0) {
-      try {
-        const tab = await browser.tabs.get(tabId);
-        if (!tab || !tab.url) {
-          return; // Tab closed or no URL
-        }
-        const currentHost = new URL(tab.url).hostname.replace(/^www\./, "");
-        const intendedHost = new URL(originUrl).hostname.replace(/^www\./, "");
-        if (currentHost !== intendedHost) {
-          // Tab navigated away from the time wasting site, abort retries
-          await this.hideImmediatePrompt(tabId).catch(() => { });
-          await this.removePreemptiveHide(tabId).catch(() => { });
-          return;
-        }
-      } catch (_) {
-        return; // Tab closed or invalid
+      if (!result) {
+        throw new Error("No response from content script");
+      } else {
+        return result
+      }
+    } catch (error) {
+      if (attempt < 20) {
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            resolve(this.sendMesssageWithRetry(tabId, attempt + 1, message));
+          }, 100);
+        });
       }
     }
+  }
 
+  async promptRedirect(tabId, learningUrl, originUrl, callbacks = {}) {
+    const { onAccept, onContinue } = callbacks;
+    
     try {
       await this.applyPreemptiveHide(tabId);
       await this.showImmediatePrompt(tabId);
-      const result = await browser.tabs.sendMessage(tabId, {
+      const result = await this.sendMesssageWithRetry(tabId, {
         action: "display: redirectPrompt",
         url: learningUrl,
         originUrl: originUrl,
@@ -58,14 +59,8 @@ class PromptCoordinator {
         }
       }
     } catch (error) {
-      if (attempt < 20) {
-        setTimeout(() => {
-          this.promptRedirect(tabId, learningUrl, originUrl, callbacks, attempt + 1);
-        }, 100);
-      } else {
-        await this.hideImmediatePrompt(tabId);
-        await this.removePreemptiveHide(tabId);
-      }
+      await this.hideImmediatePrompt(tabId);
+      await this.removePreemptiveHide(tabId);
     }
   }
 
@@ -88,13 +83,11 @@ class PromptCoordinator {
       try {
         await this.applyPreemptiveHide(details.tabId);
         await this.showImmediatePrompt(details.tabId);
-        await browser.tabs.sendMessage(details.tabId, {
+        await this.sendMesssageWithRetry(details.tabId, {
           action: "inject blocker",
         });
-        setTimeout(() => {
-          this.hideImmediatePrompt(details.tabId).catch(() => { });
-          this.removePreemptiveHide(details.tabId).catch(() => { });
-        }, 150);
+        this.hideImmediatePrompt(details.tabId).catch(() => { });
+        this.removePreemptiveHide(details.tabId).catch(() => { });
       } catch (_) { }
     }
   }

--- a/src/values/defaultSettingValues.js
+++ b/src/values/defaultSettingValues.js
@@ -13,3 +13,5 @@ export const MIN_LEARNING_MINUTES = 30;
 export const REWARD_TIME_MINUTES = 2;
 export const SESSION_TIME_MINUTES = 5; 
 export const SESSION_DURATION_OPTIONS = [5, 10, 15, 20, 25, 30];
+
+export const PROMPT_SUPPRESS_DURATION = 10 * 60 * 1000; // 10 minutes - global cooldown across all tabs


### PR DESCRIPTION
I was unable to recreate the flicker Mircea experienced [Issue](https://github.com/aiki-extension/Aiki3/issues/43), but during testing i found that the lock hastily engaged when the user refreshed on the time wasting site.

# For refresh/tab switch bug:
Cleanup accidentally resolved the promise with `"continue"`. The bug was quite hard to track down as it was not in the related lock logic due to it being a byproduct of cleanup in injection. Fix was a simple one line deletion.

For the performance minded developer. Not resolving the promise is a non issue as the script is destroyed on each refresh/tab switch.

# Housekeeping
Moved the PROMPT_SUPPRESS_DURATION constant out of src/redirection.js into src/values/defaultSettingValues.js and imported it from there to centralize configuration. Removed the duplicate local constant in redirection.js.