### PR TITLE
Bugfix: Redirect enforcement across all tabs when decision dialog is pending

### DIFF
--- a/src/redirection.js
+++ b/src/redirection.js
@@ -480,12 +480,7 @@ async function checkTab(tab) {
   const procList = await storage.list.get();
   const procListNames = procList.map((site) => site.name);
   if (procListNames.includes(tabSiteName)) {
-    const origin = await storage.origin.get();
-    if (origin) {
-      renderContentBlocker({ tabId: tab.id, frameId: 0, url: tab.url });
-    } else {
-      redirect({ frameId: 0, url: tab.url, tabId: tab.id });
-    }
+    redirect({ frameId: 0, url: tab.url, tabId: tab.id });
   }
 }
 
@@ -688,9 +683,7 @@ async function promptRedirect(tabId, url, originUrl) {
       await storage.globalPromptLock.remove();
       try {
         scheduleRevealOnLoad(tabId);
-        await browser.tabs.update(tabId, {
-          url: url,
-        });
+        await browser.tabs.update(tabId, { url: url });
         setTimeout(() => triggerLearningOverlay(tabId), 1500);
       } catch (error) {
         l(error);

--- a/src/redirection.js
+++ b/src/redirection.js
@@ -594,7 +594,7 @@ async function gotoOrigin(event, sourceContext = {}) {
     try {
       await browser.tabs.update(origin.tabId, { url: origin.url });
       destinationUrl = origin.url;
-      if (normalizedEvent === "continue") await setPromptCooldown(origin.tabId, origin.url); // ✅
+      if (normalizedEvent === "continue") await setPromptCooldown(origin.tabId, origin.url);
       restoredTabIds.add(origin.tabId);
     } catch (error) { l(error); }
   }
@@ -657,6 +657,20 @@ async function promptRedirect(tabId, url, originUrl) {
       // Set global prompt lock now that user has explicitly clicked Stay
       // This prevents the prompt from appearing again for 10 minutes (across all tabs)
       await storage.globalPromptLock.set({ timestamp: Date.now() });
+
+      // Dismiss prompts on all other tabs that are currently showing one
+      const allLocks = await storage.promptLocks.getAll();
+      await Promise.allSettled(
+        Object.keys(allLocks)
+          .map(Number)
+          .filter(id => id !== tabId)
+          .map(async (otherTabId) => {
+            await storage.promptLocks.remove(otherTabId);
+            try {
+              await browser.tabs.sendMessage(otherTabId, { action: "dismiss: redirectPrompt" });
+            } catch (_) {} // tab may have closed
+          })
+      );
 
       // Start tracking procastination session
       navigationGuards.install();

--- a/src/redirection.js
+++ b/src/redirection.js
@@ -233,7 +233,13 @@ async function redirect(details) {
             return; // We are in global cooldown period - Don't show prompt
           }
 
-          // Experimental variant: show consent prompt
+          // Check if this specific tab already has a prompt pending
+          const existingLock = await storage.promptLocks.get(details.tabId);
+          if (existingLock) {
+            l("Skipping prompt — prompt already active for this tab");
+            return;
+          }
+
           promptRedirect(details.tabId, learningUri, details.url);
         }
       }

--- a/src/redirection.js
+++ b/src/redirection.js
@@ -221,6 +221,13 @@ async function redirect(details) {
           const learningUri = await storage.learningUri.get();
           if (!learningUri) return; // skip redirection if no learning URL configured
           
+          // Check if this specific tab already has a prompt pending
+          const existingLock = await storage.promptLocks.get(details.tabId);
+          if (existingLock) {
+            l("Skipping prompt — prompt already active for this tab");
+            return;
+          }
+
           // Check global prompt lock (applies to all tabs)
           const globalPromptLock = await storage.globalPromptLock.get();  // ← GLOBAL CHECK
           const now = Date.now();
@@ -231,13 +238,6 @@ async function redirect(details) {
           ) {
             l("Skipping prompt due to global cooldown (10 minutes)");
             return; // We are in global cooldown period - Don't show prompt
-          }
-
-          // Check if this specific tab already has a prompt pending
-          const existingLock = await storage.promptLocks.get(details.tabId);
-          if (existingLock) {
-            l("Skipping prompt — prompt already active for this tab");
-            return;
           }
 
           promptRedirect(details.tabId, learningUri, details.url);
@@ -574,11 +574,9 @@ async function gotoOrigin(event, sourceContext = {}) {
     try {
       await browser.tabs.update(origin.tabId, { url: origin.url });
       destinationUrl = origin.url;
-      await setPromptCooldown(origin.tabId, origin.url);
+      if (normalizedEvent === "continue") await setPromptCooldown(origin.tabId, origin.url); // ✅
       restoredTabIds.add(origin.tabId);
-    } catch (error) {
-      l(error);
-    }
+    } catch (error) { l(error); }
   } else if (targetTabId !== undefined) {
     const blockedOrigin = await storage.blockedOrigins.get(targetTabId);
     if (blockedOrigin) {
@@ -586,11 +584,9 @@ async function gotoOrigin(event, sourceContext = {}) {
       try {
         await browser.tabs.update(targetTabId, { url: blockedOrigin });
         destinationUrl = blockedOrigin;
-        await setPromptCooldown(targetTabId, blockedOrigin);
+        if (normalizedEvent === "continue") await setPromptCooldown(targetTabId, blockedOrigin); // ✅
         restoredTabIds.add(targetTabId);
-      } catch (error) {
-        l(error);
-      }
+      } catch (error) { l(error); }
     }
   }
 
@@ -598,11 +594,9 @@ async function gotoOrigin(event, sourceContext = {}) {
     try {
       await browser.tabs.update(origin.tabId, { url: origin.url });
       destinationUrl = origin.url;
-      await setPromptCooldown(origin.tabId, origin.url);
+      if (normalizedEvent === "continue") await setPromptCooldown(origin.tabId, origin.url); // ✅
       restoredTabIds.add(origin.tabId);
-    } catch (error) {
-      l(error);
-    }
+    } catch (error) { l(error); }
   }
 
   if (shouldRestoreAllTabs && blockedTabIds.length > 0) {
@@ -662,9 +656,7 @@ async function promptRedirect(tabId, url, originUrl) {
     onContinue: async () => {
       // Set global prompt lock now that user has explicitly clicked Stay
       // This prevents the prompt from appearing again for 10 minutes (across all tabs)
-      await storage.globalPromptLock.set({  
-        timestamp: Date.now(),
-      });
+      await storage.globalPromptLock.set({ timestamp: Date.now() });
 
       // Start tracking procastination session
       navigationGuards.install();

--- a/src/redirection.js
+++ b/src/redirection.js
@@ -574,7 +574,7 @@ async function gotoOrigin(event, sourceContext = {}) {
     try {
       await browser.tabs.update(origin.tabId, { url: origin.url });
       destinationUrl = origin.url;
-      if (normalizedEvent === "continue") await setPromptCooldown(origin.tabId, origin.url); // ✅
+      if (normalizedEvent === "continue") await setPromptCooldown(origin.tabId, origin.url);
       restoredTabIds.add(origin.tabId);
     } catch (error) { l(error); }
   } else if (targetTabId !== undefined) {
@@ -584,7 +584,7 @@ async function gotoOrigin(event, sourceContext = {}) {
       try {
         await browser.tabs.update(targetTabId, { url: blockedOrigin });
         destinationUrl = blockedOrigin;
-        if (normalizedEvent === "continue") await setPromptCooldown(targetTabId, blockedOrigin); // ✅
+        if (normalizedEvent === "continue") await setPromptCooldown(targetTabId, blockedOrigin);
         restoredTabIds.add(targetTabId);
       } catch (error) { l(error); }
     }

--- a/src/services/NavigationGuards.js
+++ b/src/services/NavigationGuards.js
@@ -191,6 +191,9 @@ class NavigationGuards {
 
     this.onCommittedHandler = async (details) => {
       if (details.frameId !== 0) return;
+      if (details.transitionType === "reload") {
+        await storage.promptLocks.remove(details.tabId);
+      }
       await PreemptiveHide.revealIfPending(details.tabId, this.hideImmediatePrompt.bind(this));
       if (this.strategy?.onLearningSiteNavigation && details.url) {
         await this.strategy.onLearningSiteNavigation(details);

--- a/src/services/PromptCoordinator.js
+++ b/src/services/PromptCoordinator.js
@@ -18,20 +18,27 @@ class PromptCoordinator {
       try {
         const tab = await browser.tabs.get(tabId);
         if (!tab || !tab.url) {
-          return; // Tab closed or no URL
+          // Tab closed mid-prompt then clear the global cooldown so future visits still get prompted
+          await storage.globalPromptLock.remove();
+          return;
         }
         const currentHost = new URL(tab.url).hostname.replace(/^www\./, "");
         const intendedHost = new URL(originUrl).hostname.replace(/^www\./, "");
         if (currentHost !== intendedHost) {
-          // Tab navigated away from the time wasting site, abort retries
-          await this.hideImmediatePrompt(tabId).catch(() => { });
-          await this.removePreemptiveHide(tabId).catch(() => { });
+          await this.hideImmediatePrompt(tabId).catch(() => {});
+          await this.removePreemptiveHide(tabId).catch(() => {});
+          await storage.globalPromptLock.remove(); // navigated away without answering
           return;
         }
       } catch (_) {
-        return; // Tab closed or invalid
+        await storage.globalPromptLock.remove(); // tab closed or invalid
+        return;
       }
     }
+
+    // Set a per-tab prompt lock so other tabs see this prompt is already active
+    await storage.promptLocks.set(tabId, true);
+    await storage.globalPromptLock.set({ timestamp: Date.now() });
 
     try {
       await this.applyPreemptiveHide(tabId);
@@ -46,16 +53,15 @@ class PromptCoordinator {
         throw new Error("No response from content script");
       }
 
-      if (result && result.action === "continue") {
-        if (typeof onContinue === "function") {
-          await onContinue();
-        }
+      // Prompt was answered, so clear the per-tab lock either way
+      await storage.promptLocks.remove(tabId);
+
+      if (result.action === "continue") {
+        if (typeof onContinue === "function") await onContinue();
         await this.hideImmediatePrompt(tabId);
         await this.removePreemptiveHide(tabId);
-      } else if (result && result.action === "redirect") {
-        if (typeof onAccept === "function") {
-          await onAccept();
-        }
+      } else if (result.action === "redirect") {
+        if (typeof onAccept === "function") await onAccept();
       }
     } catch (error) {
       if (attempt < 20) {
@@ -63,8 +69,11 @@ class PromptCoordinator {
           this.promptRedirect(tabId, learningUrl, originUrl, callbacks, attempt + 1);
         }, 100);
       } else {
-        await this.hideImmediatePrompt(tabId);
-        await this.removePreemptiveHide(tabId);
+        // Exhausted retries should be treated as abandoned and clear everything
+        await storage.promptLocks.remove(tabId);
+        await storage.globalPromptLock.remove();
+        await this.hideImmediatePrompt(tabId).catch(() => {});
+        await this.removePreemptiveHide(tabId).catch(() => {});
       }
     }
   }

--- a/src/services/PromptCoordinator.js
+++ b/src/services/PromptCoordinator.js
@@ -16,6 +16,15 @@ class PromptCoordinator {
     // Validate tab still exists and is on the intended time wasting site before retrying
     if (attempt > 0) {
       try {
+        // If another tab's "Stay" set the global cooldown, abort silently
+        const globalLock = await storage.globalPromptLock.get();
+        if (globalLock && Date.now() - globalLock.timestamp < 10 * 60 * 1000) {
+          await storage.promptLocks.remove(tabId);
+          await this.hideImmediatePrompt(tabId).catch(() => {});
+          await this.removePreemptiveHide(tabId).catch(() => {});
+          return;
+        }
+
         const tab = await browser.tabs.get(tabId);
         if (!tab || !tab.url) {
           // Tab closed mid-prompt then clear the global cooldown so future visits still get prompted

--- a/src/services/PromptCoordinator.js
+++ b/src/services/PromptCoordinator.js
@@ -38,7 +38,6 @@ class PromptCoordinator {
 
     // Set a per-tab prompt lock so other tabs see this prompt is already active
     await storage.promptLocks.set(tabId, true);
-    await storage.globalPromptLock.set({ timestamp: Date.now() });
 
     try {
       await this.applyPreemptiveHide(tabId);

--- a/src/services/PromptCoordinator.js
+++ b/src/services/PromptCoordinator.js
@@ -8,10 +8,22 @@ class PromptCoordinator {
     this.showImmediatePrompt = showImmediatePrompt;
     this.hideImmediatePrompt = hideImmediatePrompt;
     this.boundRenderContentBlocker = this.renderContentBlocker.bind(this);
+    this._promptGenerations = new Map();
   }
 
   async promptRedirect(tabId, learningUrl, originUrl, callbacks = {}, attempt = 0) {
     const { onAccept, onContinue } = callbacks;
+
+    if (attempt === 0) {
+      const gen = (this._promptGenerations.get(tabId) || 0) + 1;
+      this._promptGenerations.set(tabId, gen);
+    }
+    const myGeneration = this._promptGenerations.get(tabId);
+
+    // Return if this retry is stale
+    if (attempt > 0 && this._promptGenerations.get(tabId) !== myGeneration) {
+      return;
+    }
 
     // Validate tab still exists and is on the intended time wasting site before retrying
     if (attempt > 0) {
@@ -31,8 +43,10 @@ class PromptCoordinator {
           await storage.globalPromptLock.remove();
           return;
         }
+
         const currentHost = new URL(tab.url).hostname.replace(/^www\./, "");
         const intendedHost = new URL(originUrl).hostname.replace(/^www\./, "");
+
         if (currentHost !== intendedHost) {
           await this.hideImmediatePrompt(tabId).catch(() => {});
           await this.removePreemptiveHide(tabId).catch(() => {});
@@ -51,6 +65,7 @@ class PromptCoordinator {
     try {
       await this.applyPreemptiveHide(tabId);
       await this.showImmediatePrompt(tabId);
+
       const result = await browser.tabs.sendMessage(tabId, {
         action: "display: redirectPrompt",
         url: learningUrl,
@@ -74,7 +89,15 @@ class PromptCoordinator {
     } catch (error) {
       if (attempt < 20) {
         setTimeout(() => {
-          this.promptRedirect(tabId, learningUrl, originUrl, callbacks, attempt + 1);
+          if (this._promptGenerations.get(tabId) === myGeneration) {
+            this.promptRedirect(
+              tabId,
+              learningUrl,
+              originUrl,
+              callbacks,
+              attempt + 1
+            );
+          }
         }, 100);
       } else {
         // Exhausted retries should be treated as abandoned and clear everything

--- a/src/util/storage.js
+++ b/src/util/storage.js
@@ -51,6 +51,12 @@ function createKeyedStore(storageKey) {
     },
     clear() {
       return storage.remove(storageKey);
+    },
+    async getAll() {
+      const data = await storage.get(storageKey);
+      return data[storageKey] && typeof data[storageKey] === "object"
+        ? data[storageKey]
+        : {};
     }
   };
 }
@@ -676,6 +682,7 @@ export default {
     get: getGlobalPromptLock, // Gets global lock
     set: setGlobalPromptLock, // Sets global lock
     remove: removeGlobalPromptLock, // Removes the global lock
+    getAll: promptLocksStore.getAll, // Gets all per-tab locks
   },
   participantRecord: {
     get: getParticipantRecord,

--- a/src/util/storage.js
+++ b/src/util/storage.js
@@ -677,12 +677,12 @@ export default {
     get: promptLocksStore.get,
     remove: promptLocksStore.remove,
     clear: promptLocksStore.clear,
+    getAll: promptLocksStore.getAll, // Gets all per-tab locks
   },
   globalPromptLock: {  // Global prompts
     get: getGlobalPromptLock, // Gets global lock
     set: setGlobalPromptLock, // Sets global lock
     remove: removeGlobalPromptLock, // Removes the global lock
-    getAll: promptLocksStore.getAll, // Gets all per-tab locks
   },
   participantRecord: {
     get: getParticipantRecord,


### PR DESCRIPTION
> [!WARNING]
> I have found errors in this pull request, so currently it's a waste of time to review.

# Overview
Addresses issue #44.
When a redirect prompt was shown in one tab but left unanswered, opening the same time-wasting site in a new tab would bypass the prompt entirely and grant free access. Additionally, if the unanswered tab was reloaded or closed, the global prompt cooldown would get stuck in a triggered state, preventing any future prompts from ever appearing until the 10-minute cooldown expired.
The fix introduces a per-tab prompt lock that marks a tab as "prompt active" for the duration the prompt is showing, and 'tightens' up when the global cooldown is set and cleared. This makes sure that it only activates on an explicit user choice to stay, and is always cleaned up if a prompt is abandoned.

# Before and after
## Before
<img src="https://github.com/user-attachments/assets/22e00d07-f44b-4145-8e1a-e7ce13a7a615" width="600"/>

## After
<img src="https://github.com/user-attachments/assets/bf0df019-532c-44b9-b11e-ffadaf852798" width="600"/>

# Changelogs
**Per-tab prompt locking (`PromptCoordinator.js`, `redirection.js`)**
- When a prompt is shown, `storage.promptLocks` is now set for that tab (`promptLocks.set(tabId, true)`).
- `redirect()` checks this lock before showing a prompt, and if one is already active for that tab, it returns early.
- The per-tab lock is cleared as soon as the prompt is answered (accept or continue), or when retries are exhausted.
- The per-tab check now runs before the global cooldown check in `redirect()`, so repeated navigation
  events on the same page load are caught cheaply without hitting storage for the global lock.

**Global cooldown cleanup on abandonment (`PromptCoordinator.js`)**
- If a tab is closed or navigates away while a prompt is mid-retry, `globalPromptLock` is now explicitly
  removed in all three exit paths (tab closed, navigated away, retries exhausted).
- This was the root cause of the "never prompted again" state because the lock was being left set with no path
  to clear it.

**Cooldown only set on explicit "Stay" (`redirection.js`)**
- `setPromptCooldown` in `gotoOrigin` is now guarded by `normalizedEvent === "continue"`, so the
  10-minute cooldown only activates when the user chooses to stay on the time-wasting site.
- Previously it fired on all navigation events including accepts and skips, incorrectly suppressing
  future prompts.