### PR TITLE
Bug/dragging jitter in middle of screen

### DIFF
--- a/src/injection.js
+++ b/src/injection.js
@@ -100,13 +100,6 @@ const makeDraggable = (element) => {
     return { x, y, corner };
   };
 
-  const applyRawPosition = (x, y) => {
-    element.style.left = `${x}px`;
-    element.style.top = `${y}px`;
-    element.style.right = '';
-    element.style.bottom = '';
-  }
-
   // Apply position using corner anchors
   const applyPosition = (x, y) => {
     // Clear all position properties first
@@ -150,9 +143,8 @@ const makeDraggable = (element) => {
     
     dragState.currentX = x;
     dragState.currentY = y;
-    
-    const corner = getNearestCorner();
-    applyRawPosition(x, y, corner);
+
+    applyPosition(x, y);
   };
 
   const syncIntendedPosition = () => {

--- a/src/injection.js
+++ b/src/injection.js
@@ -100,6 +100,28 @@ const makeDraggable = (element) => {
     return { x, y, corner };
   };
 
+  const applySnappedPosition = (x, y) => {
+    const rect = element.getBoundingClientRect();
+    const corner = getNearestCorner();
+    
+    element.style.left = '';
+    element.style.top = '';
+    
+    if (corner.horizontal === 'right') {
+      element.style.right = `${window.innerWidth - x - rect.width}px`;
+    } else {
+      element.style.left = `${x}px`;
+      element.style.right = '';
+    }
+    
+    if (corner.vertical === 'bottom') {
+      element.style.bottom = `${window.innerHeight - y - rect.height}px`;
+    } else {
+      element.style.top = `${y}px`;
+      element.style.bottom = '';
+    }
+  };
+
   // Apply position
   const applyPosition = (x, y) => {
     element.style.right = '';
@@ -124,7 +146,7 @@ const makeDraggable = (element) => {
     dragState.currentY = y;
     dragState.intendedX = x;
     dragState.intendedY = y;
-    applyPosition(x, y);
+    applySnappedPosition(x, y);
   };
 
   const updatePosition = (intendedX, intendedY) => {
@@ -153,7 +175,7 @@ const makeDraggable = (element) => {
     dragState.intendedY = y;
     dragState.currentX = x;
     dragState.currentY = y;
-    applyPosition(x, y);
+    applySnappedPosition(x, y);
   };
 
   const onResize = () => {
@@ -163,7 +185,7 @@ const makeDraggable = (element) => {
     dragState.intendedY = y;
     dragState.currentX = x;
     dragState.currentY = y;
-    applyPosition(x, y);
+    applySnappedPosition(x, y);
   };
 
   const onPointerDown = (event) => {
@@ -218,7 +240,7 @@ const makeDraggable = (element) => {
     dragState.intendedY = y;
     dragState.currentX = x;
     dragState.currentY = y;
-    applyPosition(x, y);
+    applySnappedPosition(x, y);
     
     if (event.pointerId !== undefined) {
       element.releasePointerCapture(event.pointerId);

--- a/src/injection.js
+++ b/src/injection.js
@@ -100,9 +100,8 @@ const makeDraggable = (element) => {
     return { x, y, corner };
   };
 
-  // Apply position using corner anchors
+  // Apply position
   const applyPosition = (x, y) => {
-    // Clear all position properties first
     element.style.right = '';
     element.style.bottom = '';
     element.style.left = `${x}px`;

--- a/src/injection.js
+++ b/src/injection.js
@@ -704,7 +704,7 @@ function renderLearningContent() {
     const isCollapsedKey = "aiki-learning-collapsed";
     let isCollapsed = localStorage.getItem(isCollapsedKey) === "true";
 
-    const getPanelStyle = (collapsed) => `pointer-events: auto; padding: ${collapsed ? "10px 14px" : "clamp(16px, 3vw, 22px)"}; min-width: ${collapsed ? "140px" : "260px"}; max-width: ${collapsed ? "180px" : "320px"}; background: rgba(15, 23, 42, 0.96); color: #f8fafc; border-radius: ${collapsed ? "12px" : "18px"}; box-shadow: 0 24px 45px rgba(15, 23, 42, 0.45); font-family: 'Inter', 'Segoe UI', sans-serif; display: flex; flex-direction: column; gap: ${collapsed ? "6px" : "12px"}; cursor: grab; position: relative; font-size: 14px; transition: all 0.3s ease;`;
+    const getPanelStyle = (collapsed) => `pointer-events: auto; padding: ${collapsed ? "10px 14px" : "clamp(16px, 3vw, 22px)"}; min-width: ${collapsed ? "140px" : "260px"}; max-width: ${collapsed ? "180px" : "320px"}; margin: 8px; background: rgba(15, 23, 42, 0.96); color: #f8fafc; border-radius: ${collapsed ? "12px" : "18px"}; box-shadow: 0 24px 45px rgba(15, 23, 42, 0.45); font-family: 'Inter', 'Segoe UI', sans-serif; display: flex; flex-direction: column; gap: ${collapsed ? "6px" : "12px"}; cursor: grab; position: relative; font-size: 14px; transition: all 0.3s ease;`;
 
     function updateOverlayVisibility() {
       if (isFullScreen()) {

--- a/src/injection.js
+++ b/src/injection.js
@@ -104,21 +104,42 @@ const makeDraggable = (element) => {
     const rect = element.getBoundingClientRect();
     const corner = getNearestCorner();
     
-    element.style.left = '';
-    element.style.top = '';
+    // Instantly convert to the target coordinate system (no transition)
+    const prevTransition = element.style.transition;
+    element.style.transition = 'none';
     
     if (corner.horizontal === 'right') {
-      element.style.right = `${window.innerWidth - x - rect.width}px`;
+      element.style.left = '';
+      element.style.right = `${window.innerWidth - rect.right}px`;
     } else {
-      element.style.left = `${x}px`;
       element.style.right = '';
+      element.style.left = `${rect.left}px`;
     }
     
     if (corner.vertical === 'bottom') {
-      element.style.bottom = `${window.innerHeight - y - rect.height}px`;
+      element.style.top = '';
+      element.style.bottom = `${window.innerHeight - rect.bottom}px`;
     } else {
-      element.style.top = `${y}px`;
       element.style.bottom = '';
+      element.style.top = `${rect.top}px`;
+    }
+    
+    // Force reflow
+    element.getBoundingClientRect();
+    
+    // Re-enable transition and animate to snapped position
+    element.style.transition = prevTransition;
+    
+    if (corner.horizontal === 'right') {
+      element.style.right = '0px';
+    } else {
+      element.style.left = '0px';
+    }
+    
+    if (corner.vertical === 'bottom') {
+      element.style.bottom = '0px';
+    } else {
+      element.style.top = '0px';
     }
   };
 
@@ -194,6 +215,16 @@ const makeDraggable = (element) => {
     if (event.target.tagName === 'BUTTON' || event.target.closest('button')) {
       return;
     }
+
+    const rect = element.getBoundingClientRect();
+    element.style.right = '';
+    element.style.bottom = '';
+    element.style.left = `${rect.left}px`;
+    element.style.top = `${rect.top}px`;
+    dragState.currentX = rect.left;
+    dragState.currentY = rect.top;
+    dragState.intendedX = rect.left;
+    dragState.intendedY = rect.top;
 
     dragState.dragging = true;
     dragState.startX = event.clientX;

--- a/src/injection.js
+++ b/src/injection.js
@@ -100,6 +100,13 @@ const makeDraggable = (element) => {
     return { x, y, corner };
   };
 
+  const applyRawPosition = (x, y) => {
+    element.style.left = `${x}px`;
+    element.style.top = `${y}px`;
+    element.style.right = '';
+    element.style.bottom = '';
+  }
+
   // Apply position using corner anchors
   const applyPosition = (x, y, corner) => {
     const rect = element.getBoundingClientRect();
@@ -162,7 +169,7 @@ const makeDraggable = (element) => {
     dragState.currentY = y;
     
     const corner = getNearestCorner();
-    applyPosition(x, y, corner);
+    applyRawPosition(x, y, corner);
   };
 
   const syncIntendedPosition = () => {

--- a/src/injection.js
+++ b/src/injection.js
@@ -108,29 +108,12 @@ const makeDraggable = (element) => {
   }
 
   // Apply position using corner anchors
-  const applyPosition = (x, y, corner) => {
-    const rect = element.getBoundingClientRect();
-    
+  const applyPosition = (x, y) => {
     // Clear all position properties first
-    element.style.left = '';
     element.style.right = '';
-    element.style.top = '';
     element.style.bottom = '';
-    
-    // Apply appropriate corner anchors
-    if (corner.horizontal === 'right') {
-      const rightOffset = window.innerWidth - x - rect.width;
-      element.style.right = `${rightOffset}px`;
-    } else {
-      element.style.left = `${x}px`;
-    }
-    
-    if (corner.vertical === 'bottom') {
-      const bottomOffset = window.innerHeight - y - rect.height;
-      element.style.bottom = `${bottomOffset}px`;
-    } else {
-      element.style.top = `${y}px`;
-    }
+    element.style.left = `${x}px`;
+    element.style.top = `${y}px`;
   };
 
   const initializePosition = () => {
@@ -144,12 +127,12 @@ const makeDraggable = (element) => {
     element.style.transform = 'none';
     
     // Snap to nearest corner on init
-    const { x, y, corner } = snapToCorner();
+    const { x, y } = snapToCorner();
     dragState.currentX = x;
     dragState.currentY = y;
     dragState.intendedX = x;
     dragState.intendedY = y;
-    applyPosition(x, y, corner);
+    applyPosition(x, y);
   };
 
   const updatePosition = (intendedX, intendedY) => {
@@ -174,22 +157,22 @@ const makeDraggable = (element) => {
 
   const syncIntendedPosition = () => {
     // Snap to nearest corner when size changes
-    const { x, y, corner } = snapToCorner();
+    const { x, y } = snapToCorner();
     dragState.intendedX = x;
     dragState.intendedY = y;
     dragState.currentX = x;
     dragState.currentY = y;
-    applyPosition(x, y, corner);
+    applyPosition(x, y);
   };
 
   const onResize = () => {
     // Snap to corner on resize
-    const { x, y, corner } = snapToCorner();
+    const { x, y } = snapToCorner();
     dragState.intendedX = x;
     dragState.intendedY = y;
     dragState.currentX = x;
     dragState.currentY = y;
-    applyPosition(x, y, corner);
+    applyPosition(x, y);
   };
 
   const onPointerDown = (event) => {
@@ -239,12 +222,12 @@ const makeDraggable = (element) => {
     element.style.cursor = "grab";
     
     // Snap to nearest corner when drag ends
-    const { x, y, corner } = snapToCorner();
+    const { x, y } = snapToCorner();
     dragState.intendedX = x;
     dragState.intendedY = y;
     dragState.currentX = x;
     dragState.currentY = y;
-    applyPosition(x, y, corner);
+    applyPosition(x, y);
     
     if (event.pointerId !== undefined) {
       element.releasePointerCapture(event.pointerId);


### PR DESCRIPTION
# Bug itself
Beforehand, when the user would drag the popup injection window towards the middle of the screen, it would jitter slightly. This wasn't a huge deal breaker, but was a minor annoyance that needed to be fixed. 

### Positioning Logic Refactor
- Removed corner-based positioning logic from `applyPosition`
- Updated `applyPosition` to always use `left` and `top`
- Created a new `applySnappedPosition` function, to handle translating from top/left to bottom/right and then do the proper transitions

## Explanation of the bug fix
The cause of the bug was that the logic to snap to a corner once done dragging, was actually running constantly even when the user was dragging the window still. To fix it, it would only be applied when the user was done dragging.

### Second bug fix explanation
As a result of this, the popup window now instantly snapped to the right side, but had a smooth transition to the left side. This was caused as the previous logic had divided the screen in "left side" and "right side". The problem of this, is that when the CSS transition has to do the transition, it can't smoothly go from "left" to "right". My initial fix for this, was to only use top and left directions. Since CSS transitions can handle going from 300 left pixels to 100 left pixels for example. 

Though this caused issues with resizing, as the extension now couldn't quite figure out where to place the resized window. Thus right/bottom logic was in fact still needed. So to circumvent the whole transition from left to right issue, I had to first translate the coordinates from a top/left logic to the right/bottom logic, force a reflow to ensure that the browser commits to it, and then do the translation. In this way we simply just do a transition from x right/bottom placement to another right/bottom placement. Which means that the transition can run smoothly just as it did before 