### PR TITLE
Update/all urls same format

### DIFF
--- a/src/Pages/Components/Settings/SetRedirection.svelte
+++ b/src/Pages/Components/Settings/SetRedirection.svelte
@@ -36,14 +36,6 @@
     isEditing = !hasSaved;
   });
 
-  function normalize(url) {
-    if (!url) return "";
-    const trimmed = url.trim();
-    if (!trimmed) return "";
-    if (/^https?:\/\//i.test(trimmed)) return trimmed;
-    return `https://${trimmed}`;
-  }
-
   async function saveUri() {
     if (!isEditing) return;
 
@@ -114,7 +106,7 @@
       <input
         class="form-control form-control-lg url-input"
         type="text"
-        placeholder="https://example.com"
+        placeholder="www.example.com"
         bind:value={learningUri}
         bind:this={urlInputRef}
         readonly={!isEditing}

--- a/src/Pages/Components/Settings/SetRedirection.svelte
+++ b/src/Pages/Components/Settings/SetRedirection.svelte
@@ -62,11 +62,6 @@
       return;    
     }
 
-    const backendResult = await browser.runtime.sendMessage({
-      type: MESSAGE_API_UPDATE_LEARNING_URI,
-      learningUri: wwwHost,
-    });
-
     await storage.learningUri.set(wwwHost);
     learningUri = wwwHost; // Used to display it correctly in the settings page
 
@@ -77,6 +72,12 @@
         type: 'success',
         message: 'Learning platform saved!',
       })
+    
+    // API Call at the end, to ensure it doesn't block for local storage (focused on guest mode especially)
+    const backendResult = await browser.runtime.sendMessage({
+      type: MESSAGE_API_UPDATE_LEARNING_URI,
+      learningUri: wwwHost,
+    });
   }
 
   async function enableEditing() {

--- a/src/Pages/Components/Settings/SetRedirection.svelte
+++ b/src/Pages/Components/Settings/SetRedirection.svelte
@@ -6,7 +6,7 @@
   // Functional and module imports
   import storage from "../../../util/storage";
   import { onMount, tick } from "svelte";
-  import { parseUrl } from "../../../util/utilities";
+  import { parseUrl, normalizeUrl } from "../../../util/utilities";
   import { alertStore } from '../../../services/alertService';
   import browser from "webextension-polyfill";
   import { MESSAGE_API_UPDATE_LEARNING_URI } from '../../../values/messageTypeValues';
@@ -47,12 +47,22 @@
   async function saveUri() {
     if (!isEditing) return;
 
-    const uri = normalize(learningUri);
+    const wwwHost = normalizeUrl(learningUri);
 
-    const hostToCompare = parseUrl(uri).host; // Get just the domain (e.g., "example.com")
+    if (!wwwHost) {
+      if (!learningUri.trim()){
+        await storage.learningUri.set("");
+        hasSaved = false;
+        isEditing = true;
+        alertStore.add({ type: 'success', message: 'Learning platform cleared.' });
+      } else {
+        alertStore.add({ type: 'warning', message: 'Invalid URL.' });
+      }
+      return;
+    }
 
     const timeWasteList = (await storage.list.get()) || [];
-    if (timeWasteList.some(item => item.host === hostToCompare)) {
+    if (timeWasteList.some(item => item.host === wwwHost)) {
       alertStore.add({
         type: 'warning',
         message: 'Your learning site cant be the same as a time wasting site',
@@ -62,21 +72,11 @@
 
     const backendResult = await browser.runtime.sendMessage({
       type: MESSAGE_API_UPDATE_LEARNING_URI,
-      learningUri: uri,
+      learningUri: wwwHost,
     });
 
-    if (!uri) {
-      await storage.learningUri.set("");
-      hasSaved = false;
-      isEditing = true;
-      alertStore.add({
-        type: 'success',
-        message: 'Learning platform cleared.',
-      })
-      return;
-    }
-
-    await storage.learningUri.set(uri);
+    await storage.learningUri.set(wwwHost);
+    learningUri = wwwHost; // Used to display it correctly in the settings page
 
     hasSaved = true;
     isEditing = false;

--- a/src/Pages/Components/Settings/SetTimeWastingSites.svelte
+++ b/src/Pages/Components/Settings/SetTimeWastingSites.svelte
@@ -5,7 +5,7 @@
 <script>
   import Container from "./Container.svelte";
   import storage from "../../../util/storage";
-  import { parseUrl } from "../../../util/utilities";
+  import { parseUrl, normalizeUrl } from "../../../util/utilities";
   import Fa from "svelte-fa";
   import {
     faTrashAlt,
@@ -108,23 +108,18 @@
       return;
     }
 
-    // Used to normalize input to always be www.domain.tld
-    let rawInput = addItemValue.trim();
-    rawInput = new URL(rawInput.startsWith("http") ? rawInput : `https://${rawInput}`).hostname ?? rawInput;
+    const normalized = normalizeUrl(addItemValue);
 
-    const urlPattern = /(?:https?:\/\/)?(?:www\.)?([a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.[a-zA-Z]{2,})(?:[/?#].*)?$/;
-    const match = rawInput.match(urlPattern);
-
-    if (!match) {
+    if (!normalized) {
       alertStore.add({
         type: 'warning',
-        message: 'Invalid URL format!',
+        message: 'Invalid URL format!'
       })
       return;
     }
 
-    // The site that has been normalized, now becomes "www.x.x" and stored in addItemvalue
-    addItemValue = `www.${match[1]}`;
+    // The site that has been normalized, now becomes "www.example.com" and stored in addItemvalue
+    addItemValue = normalized;
 
     learningUri = parseUrl(await storage.learningUri.get())
     let site = parseUrl(addItemValue);

--- a/src/handlers/messageHandler.js
+++ b/src/handlers/messageHandler.js
@@ -3,6 +3,7 @@ import timer from "../services/TimerManager";
 import browser from "webextension-polyfill";
 import { parseTime } from "../util/utilities";
 import { handleApiMessage } from "./apiHandler";
+import { getLearningUrl } from "../services/siteDetector";
 
 /*
 This module handles incoming messages from content scripts and other parts of the extension.
@@ -155,7 +156,7 @@ if (!message || typeof message !== "object") {
             const tabs = await browser.tabs.query({ active: true, currentWindow: true });
             if (tabs.length > 0 && tabs[0].id && tabs[0].url) {
               const currentUrl = tabs[0].url;
-              const learningUrl = await storage.learningUri.get();
+              const learningUrl = await getLearningUrl();
               
               // Checks if URL matches learning site
               const isOnLearningSite = (url, learningUri) => {

--- a/src/injection.js
+++ b/src/injection.js
@@ -1,4 +1,5 @@
 import browser from "webextension-polyfill";
+import { getLearningUrl } from "./services/siteDetector";
 
 const l = console.log;
 
@@ -378,9 +379,7 @@ async function bootstrapLearningOverlayIfNeeded() {
   if (bootstrapAttemptPending) return;
   bootstrapAttemptPending = true;
   try {
-    const result = await browser.storage.local.get("learningUri");
-    const learningUri =
-      result && typeof result.learningUri === "string" ? result.learningUri.trim() : "";
+    const learningUri = await getLearningUrl();
     if (!learningUri || !matchesLearningHost(learningUri)) {
       bootstrapAttemptPending = false;
       return;
@@ -1080,8 +1079,8 @@ function renderContentBlocker() {
 
   button.addEventListener("click", async () => {
     try {
-      const result = await browser.storage.local.get("learningUri");
-      const uri = result && typeof result.learningUri === "string" ? result.learningUri.trim() : "";
+      const result = await getLearningUrl();
+      const uri = (typeof result === "string" ? result.trim() : "");
       if (uri) {
         cleanup();
         location.href = uri;

--- a/src/redirection.js
+++ b/src/redirection.js
@@ -5,6 +5,7 @@ import { parseUrl, makeDate, parseTime } from "./util/utilities";
 import SessionService from "./services/SessionService";
 import NavigationGuards from "./services/NavigationGuards";
 import PromptCoordinator from "./services/PromptCoordinator";
+import { getLearningUrl } from "./services/siteDetector";
 
 const l = console.log;
 
@@ -135,7 +136,7 @@ async function originUpdatedListener(details) {
     if (origin.tabId === details) {
       const tab = await browser.tabs.get(details);
       l(tab);
-      const currentLearning = await storage.learningUri.get();
+      const currentLearning = await getLearningUrl();
       const learningName = parseUrl(currentLearning).name;
       if (tab.url.includes(learningName)) {
         storage.learningUri.set(tab.url);
@@ -161,7 +162,7 @@ async function redirect(details) {
 
       const procList = await storage.list.get();
       const procHosts = (procList || []).map(item => item?.host || item?.name || "").filter(Boolean);
-      const learningUrl = await storage.learningUri.get();
+      const learningUrl = await getLearningUrl();
 
       const handled = await strategy.handleNavigation(details, {
         applyPreemptiveHide: (tabId) => navigationGuards.applyPreemptiveHide(tabId),
@@ -195,7 +196,7 @@ async function redirect(details) {
         if (origin && origin.tabId !== undefined) {
           try {
             const originTab = await browser.tabs.get(origin.tabId);
-            const learningUri = await storage.learningUri.get();
+            const learningUri = await getLearningUrl();
             if (originTab && learningUri) {
               const learningName = parseUrl(learningUri).name;
               if (learningName && originTab.url && originTab.url.includes(learningName)) {
@@ -218,7 +219,7 @@ async function redirect(details) {
         }
 
         if (!origin || isOriginValid) {
-          const learningUri = await storage.learningUri.get();
+          const learningUri = await getLearningUrl();
           if (!learningUri) return; // skip redirection if no learning URL configured
           
           // Check global prompt lock (applies to all tabs)
@@ -270,7 +271,7 @@ async function onOriginRemoved(details) {
   const origin = await storage.origin.get();
   if (origin) {
     if (details === origin.tabId) {
-      const learningUri = await storage.learningUri.get();
+      const learningUri = await getLearningUrl();
       let migrated = false;
       if (learningUri) {
         const learningName = parseUrl(learningUri).name;
@@ -311,7 +312,7 @@ async function onOriginRemoved(details) {
 }
 
 async function addLearningSiteLoadedListener() {
-  const currentLearning = await storage.learningUri.get();
+  const currentLearning = await getLearningUrl();
   if (!currentLearning) return;
   const learningName = parseUrl(currentLearning).name;
   if (!learningName) return;
@@ -326,7 +327,7 @@ async function addLearningSiteLoadedListener() {
  */
 async function addControlledLearningSiteListener() {
 
-  const currentLearning = await storage.learningUri.get();
+  const currentLearning = await getLearningUrl();
   if (!currentLearning) return;
   const learningName = parseUrl(currentLearning).name;
   if (!learningName) return;
@@ -351,7 +352,7 @@ function removeLearningSiteLoadedListener() {
 }
 
 async function getActiveLearningTabs(excludedIds = new Set()) {
-  const learningUri = await storage.learningUri.get();
+  const learningUri = await getLearningUrl();
   if (!learningUri) return [];
   const learningName = parseUrl(learningUri).name;
   if (!learningName) return [];
@@ -431,7 +432,7 @@ async function checkActiveTab() {
       const procList = await storage.list.get();
       const procListNames = procList.map((site) => site.name);
       if (procListNames.includes(tabSiteName)) {
-        const learningUri = await storage.learningUri.get();
+        const learningUri = await getLearningUrl();
         if (!learningUri) return; // no learning site set; do nothing
 
         const procHosts = procList.map(item => item?.host || item?.name || "").filter(Boolean);
@@ -547,7 +548,7 @@ async function gotoOrigin(event, sourceContext = {}) {
   if (origin && origin.tabId !== undefined) {
     try {
       const learningTab = await browser.tabs.get(origin.tabId);
-      const configuredLearning = await storage.learningUri.get();
+      const configuredLearning = await getLearningUrl();
       if (configuredLearning) {
         const configuredName = parseUrl(configuredLearning).name;
         const currentName = parseUrl(learningTab.url).name;

--- a/src/services/TimerManager.js
+++ b/src/services/TimerManager.js
@@ -1,6 +1,7 @@
 import storage from "../util/storage";
 import browser from "webextension-polyfill";
 import { parseTime, parseUrl } from "../util/utilities";
+import { getLearningUrl } from "./siteDetector";
 
 class TimerManager {
   constructor() {
@@ -233,7 +234,7 @@ class TimerManager {
         const origin = await storage.origin.get();
 
         try {
-          const learningUri = await storage.learningUri.get();
+          const learningUri = await getLearningUrl();
           const learningName = learningUri ? parseUrl(learningUri).name : "";
 
           // Only count as active if the current tab is both the origin tab AND still on the learning host

--- a/src/services/siteDetector.js
+++ b/src/services/siteDetector.js
@@ -59,7 +59,7 @@ export async function getProcrastinationHosts() {
 export async function getLearningUrl() {
   const url = await storage.learningUri.get();
   if (!url) return null;
-  return `https://${url}`; // "https://www.example.com" - only for navigation
+  return `http://${url}`; // "http://www.example.com" - only for navigation
 }
 
 /**

--- a/src/services/siteDetector.js
+++ b/src/services/siteDetector.js
@@ -58,7 +58,8 @@ export async function getProcrastinationHosts() {
  */
 export async function getLearningUrl() {
   const url = await storage.learningUri.get();
-  return url || null;
+  if (!url) return null;
+  return `https://${url}`; // "https://www.example.com" - only for navigation
 }
 
 /**

--- a/src/services/siteDetector.js
+++ b/src/services/siteDetector.js
@@ -59,7 +59,8 @@ export async function getProcrastinationHosts() {
 export async function getLearningUrl() {
   const url = await storage.learningUri.get();
   if (!url) return null;
-  return `http://${url}`; // "http://www.example.com" - only for navigation
+  // Only prepend http:// if the URL doesn't already have a protocol
+  return url.match(/^https?:\/\//) ? url : `http://${url}`;
 }
 
 /**

--- a/src/util/utilities.js
+++ b/src/util/utilities.js
@@ -65,6 +65,16 @@ export function parseUrl(site) {
   return { host, name };
 }
 
+export function normalizeUrl(input) {
+  if (!input?.trim()) return null;
+  const { host } = parseUrl(input);
+  if (!host) return null;
+  const urlPattern = /(?:https?:\/\/)?(?:www\.)?([a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.[a-zA-Z]{2,})(?:[/?#].*)?$/;
+  const match = host.match(urlPattern);
+  if (!match) return null;
+  return host.startsWith("www.") ? host : `www.${host}`;
+}
+
 export function makeDate() {
   const options = {
     weekday: "long",


### PR DESCRIPTION
# Intro
Beforehand URL's for timewasting sites was stored as www.github.com whilst for time learning sites, it would be stored as https://www.github.com. Whilst a small difference, it would mean that in the backend we would have a website called www.github.com and one with the https:// version. Essentially two entries for the same website, thus redundancy.

## The fix itself
This PR focuses on unifying this, such that all URL's are kept in the same format when stored "www.example.com". One issue with this though, was that learning sites needed protocols to be able to act as proper links. Otherwise, the extension would think that the user was trying to access a file locally, which isn't the case.

To fix that `siteDetector.js`'s getLearningURL() function was used to be able to fetch the learning url, but then prepend "http://" to it. This allows for it to be seen as a proper link, and the website will then redirect properly to use HTTPS if they use it (which is most of the cases).

