### PR TITLE
Skip API calls for guest users

### DIFF
--- a/src/handlers/apiHandler.js
+++ b/src/handlers/apiHandler.js
@@ -1,4 +1,5 @@
 import { loginUser, registerUser, updateUserSettings, getUserSettings, deleteTimeWastingSite } from "../services/apiService";
+import storage from "../util/storage";
 import { fetchAndSyncSettings } from "../services/settingsService";
 import { REWARD_TIME_MINUTES } from "../values/defaultSettingValues";
 import { 
@@ -22,6 +23,11 @@ function toTokenResult(result) {
 }
 
 export async function handleApiMessage(message) {
+  const uid = await storage.uid.get();
+  if (uid === "guest") {
+    return { ok: true, message: "" };
+  }
+
   if (message.type === MESSAGE_API_LOGIN) {
     const result = await loginUser({ email: message.email, password: message.password });
     const validated = toTokenResult(result);


### PR DESCRIPTION
Adds a check in the `handleApiMessage` function to bypass API message handling for guest users. 
If the user ID retrieved from storage is `"guest"`, the function immediately returns a success response with an empty message, preventing further processing. This check is done at the top of `handleApiMessage` to return early for guest users.

Addresses issue #58

![20260404-1237-18 3256634-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/3fad97ea-ef61-4eb6-8625-ccd79b1e6c27)
