### PR TITLE
Fix: Storage reset, default settings, and stale state on sign-out / guest login

### DIFF
--- a/src/Pages/Components/Settings/SetTimeWastingSites.svelte
+++ b/src/Pages/Components/Settings/SetTimeWastingSites.svelte
@@ -68,6 +68,7 @@
 
   async function removeItem(index) {
     const domain = list[index].host;
+    let result;
 
     let newList = [...list];
     newList.splice(index, 1);
@@ -80,7 +81,7 @@
       })
 
     try {
-      const result = await browser.runtime.sendMessage({
+      result = await browser.runtime.sendMessage({
         type: MESSAGE_API_REMOVE_TIME_WASTING_SITE,
         domain: domain
       });

--- a/src/Pages/Components/Settings/SetUser.svelte
+++ b/src/Pages/Components/Settings/SetUser.svelte
@@ -185,7 +185,12 @@
         return;
       }
 
-      persistSessionLocally(normalizedUser, authResult.token);
+      await persistSessionLocally(normalizedUser, authResult.token);
+      await storage.shouldRedirect.set(true);
+      const redirectionEnabled = await storage.redirection.get();
+      if (redirectionEnabled !== true) {
+        await storage.redirection.toggle();
+      }
 
       // After successful login/register, notify parent (Settings.svelte) 
       // so it can sync DB settings to local storage and re-render child components

--- a/src/Pages/Components/Settings/SetUser.svelte
+++ b/src/Pages/Components/Settings/SetUser.svelte
@@ -28,8 +28,6 @@
 
   export let user = "";
   export let userIsRegistered;
-  export let port;
-  void port;
   let authMode = "login";
   let password = "";
   let confirmPassword = "";

--- a/src/Pages/Components/Settings/SetUser.svelte
+++ b/src/Pages/Components/Settings/SetUser.svelte
@@ -19,6 +19,7 @@
   export let user = "";
   export let userIsRegistered;
   export let port;
+  void port;
   let authMode = "login";
   let password = "";
   let confirmPassword = "";
@@ -67,6 +68,9 @@
   }
 
   async function clearSessionLocally() {
+    await storage.clearStorage();
+    await storage.shouldRedirect.set(true);
+    await storage.redirection.toggle();
     await storage.jwt.set("");
     await storage.uid.set("");
     await storage.inviteCode.set("");
@@ -289,6 +293,7 @@
               href="#guest"
               class="auth-switch-link"
               on:click|preventDefault={async () => {
+                await clearSessionLocally();
                 await persistSessionLocally("guest", null);
                 notifySuccess("You are now signed in as a guest.");
               }}

--- a/src/Pages/Components/Settings/SetUser.svelte
+++ b/src/Pages/Components/Settings/SetUser.svelte
@@ -6,11 +6,21 @@
   import { onMount } from "svelte";
   import Container from "./Container.svelte";
   import storage from "../../../util/storage";
+  import { setTheme } from "../../../util/themes";
   import Fa from "svelte-fa";
   import { faUserSlash, faUserPlus } from "@fortawesome/free-solid-svg-icons";
   import { alertStore } from "../../../services/alertService";
   import browser from "webextension-polyfill";
   import {createEventDispatcher } from "svelte";
+  import {
+    ACTIVE_TIME_TO_HOURS,
+    ACTIVE_TIME_TO_MINUTES,
+    ACTIVE_TIME_FROM_HOURS,
+    ACTIVE_TIME_FROM_MINUTES,
+    MIN_LEARNING_MINUTES,
+    REWARD_TIME_MINUTES,
+    SESSION_TIME_MINUTES,
+  } from "../../../values/defaultSettingValues";
   import {
     MESSAGE_API_LOGIN,
     MESSAGE_API_REGISTER
@@ -67,13 +77,30 @@
     userIsRegistered = true;
   }
 
-  async function clearSessionLocally() {
+  async function loadDefaultSettingsLocally() {
+    await storage.operatingHours.from.set({
+      hrs: ACTIVE_TIME_FROM_HOURS,
+      min: ACTIVE_TIME_FROM_MINUTES,
+    });
+    await storage.operatingHours.to.set({
+      hrs: ACTIVE_TIME_TO_HOURS,
+      min: ACTIVE_TIME_TO_MINUTES,
+    });
+    await storage.timeSettings.learningTime.set({ min: MIN_LEARNING_MINUTES, sec: 0 });
+    await storage.timeSettings.sessionMinutes.set(SESSION_TIME_MINUTES);
+    await storage.timeSettings.sessionSeconds.set(0);
+    await storage.timeSettings.rewardMinutes.set(REWARD_TIME_MINUTES);
+    await storage.timeSettings.rewardSeconds.set(0);
+  }
+
+  async function clearSessionLocally({ loadDefaults = false } = {}) {
     await storage.clearStorage();
-    await storage.shouldRedirect.set(true);
-    await storage.redirection.toggle();
-    await storage.jwt.set("");
-    await storage.uid.set("");
-    await storage.inviteCode.set("");
+    await setTheme("dark");
+    if (loadDefaults) {
+      await loadDefaultSettingsLocally();
+      await storage.shouldRedirect.set(true);
+      await storage.redirection.toggle();
+    }
     user = "";
     userIsRegistered = false;
   }
@@ -172,7 +199,7 @@
 
   async function resetUid() {
     if (!confirm("Are you sure you want to sign out?")) return;
-    await clearSessionLocally();
+    await clearSessionLocally({ loadDefaults: false });
     resetFormFields();
     authMode = "login";
     notifySuccess("You have been signed out.");
@@ -293,7 +320,7 @@
               href="#guest"
               class="auth-switch-link"
               on:click|preventDefault={async () => {
-                await clearSessionLocally();
+                await clearSessionLocally({ loadDefaults: true });
                 await persistSessionLocally("guest", null);
                 notifySuccess("You are now signed in as a guest.");
               }}

--- a/src/Pages/Components/Settings/TimeSelector.svelte
+++ b/src/Pages/Components/Settings/TimeSelector.svelte
@@ -4,7 +4,7 @@
 <script>
   import { onMount } from "svelte";
   import storage from "../../../util/storage";
-  import { SESSION_DURATION_OPTIONS } from '../../../values/defaultSettingValues';
+  import { SESSION_DURATION_OPTIONS } from "../../../values/defaultSettingValues";
   import browser from "webextension-polyfill";
   import { alertStore } from "../../../services/alertService";
   import { 

--- a/src/Pages/Settings.svelte
+++ b/src/Pages/Settings.svelte
@@ -72,7 +72,7 @@
     {/if}
     <div class="container">
       <!-- Listens for the "authenticated" event in SetUser.svelte. Thus triggering the function to trigger, to refresh values on the page-->
-      <SetUser bind:user bind:userIsRegistered {port} on:authenticated={handleAuthenticated} />
+      <SetUser bind:user bind:userIsRegistered on:authenticated={handleAuthenticated} />
     </div>
     {#if userIsRegistered}
       <div class="container">

--- a/src/handlers/apiHandler.js
+++ b/src/handlers/apiHandler.js
@@ -33,6 +33,8 @@ export async function handleApiMessage(message) {
     const validated = toTokenResult(result);
 
     if (validated.ok) {
+      // Has to restart listener, as when the user logs in, they will have an empty list of timewasting sites.
+      // Without this, it would never restart and actually check on the sites the user has added. It would check on the "old" list, which most likely was empty
       await redirection.navigationListener.restart();
     }
     return validated;

--- a/src/handlers/apiHandler.js
+++ b/src/handlers/apiHandler.js
@@ -1,7 +1,6 @@
 import { loginUser, registerUser, updateUserSettings, getUserSettings, deleteTimeWastingSite } from "../services/apiService";
 import storage from "../util/storage";
 import { fetchAndSyncSettings } from "../services/settingsService";
-import { REWARD_TIME_MINUTES } from "../values/defaultSettingValues";
 import redirection from "../redirection";
 import { 
   MESSAGE_API_LOGIN,

--- a/src/handlers/apiHandler.js
+++ b/src/handlers/apiHandler.js
@@ -1,6 +1,5 @@
 import { loginUser, registerUser, updateUserSettings, getUserSettings, deleteTimeWastingSite } from "../services/apiService";
 import storage from "../util/storage";
-import { fetchAndSyncSettings } from "../services/settingsService";
 import redirection from "../redirection";
 import { 
   MESSAGE_API_LOGIN,
@@ -34,16 +33,6 @@ export async function handleApiMessage(message) {
     const validated = toTokenResult(result);
 
     if (validated.ok) {
-      try {
-        const syncResult = await fetchAndSyncSettings();
-        if (!syncResult.ok) {
-          console.warn("[Settings] Could not sync settings on login:", syncResult.message);
-        }
-      } catch (e) {
-        console.warn("[Settings] fetchAndSyncSettings crashed: ", e);
-      }
-      // Has to restart listener, as when the user logs in, they will have an empty list of timewasting sites.
-      // Without this, it would never restart and actually check on the sites the user has added. It would check on the "old" list, which most likely was empty
       await redirection.navigationListener.restart();
     }
     return validated;

--- a/src/handlers/messageHandler.js
+++ b/src/handlers/messageHandler.js
@@ -5,6 +5,7 @@ import { parseTime } from "../util/utilities";
 import { handleApiMessage } from "./apiHandler";
 import redirection from "../redirection";
 import { getLearningUrl } from "../services/siteDetector";
+import { MESSAGE_REDIRECTION_REFRESH_FILTERS } from "../values/messageTypeValues";
 
 /*
 This module handles incoming messages from content scripts and other parts of the extension.
@@ -27,6 +28,15 @@ if (!message || typeof message !== "object") {
   if (message.type === "contentScript:ready" && sender?.tab?.id !== undefined) {
     redirection.onContentScriptReady(sender.tab.id);
     return;
+  }
+
+  if (message.type === MESSAGE_REDIRECTION_REFRESH_FILTERS) {
+    try {
+      await redirection.navigationListener.restart();
+      return { ok: true };
+    } catch (_) {
+      return { ok: false };
+    }
   }
 
   if (message.type === "timer:get") {

--- a/src/redirection.js
+++ b/src/redirection.js
@@ -5,7 +5,7 @@ import { parseUrl, makeDate, parseTime } from "./util/utilities";
 import SessionService from "./services/SessionService";
 import NavigationGuards from "./services/NavigationGuards";
 import PromptCoordinator from "./services/PromptCoordinator";
-import { PROMPT_SUPPRESS_DURATION } from "../src/values/defaultSettingValues"
+import { PROMPT_SUPPRESS_DURATION } from "./values/defaultSettingValues";
 import { getLearningUrl } from "./services/siteDetector";
 
 const l = console.log;

--- a/src/services/settingsService.js
+++ b/src/services/settingsService.js
@@ -1,6 +1,6 @@
 import browser from "webextension-polyfill";
 import storage from "../util/storage";
-import { MESSAGE_API_GET_USER_SETTINGS } from "../values/messageTypeValues";
+import { MESSAGE_API_GET_USER_SETTINGS, MESSAGE_REDIRECTION_REFRESH_FILTERS } from "../values/messageTypeValues";
 import { parseUrl } from "../util/utilities";
 import { alertStore } from "../services/alertService";
 
@@ -27,6 +27,7 @@ export async function fetchAndSyncSettings() {
     if (!result.ok) return { ok: false, message: result.message };
 
     await syncDBSettingsToLocalStorage(result.data);
+    await browser.runtime.sendMessage({ type: MESSAGE_REDIRECTION_REFRESH_FILTERS });
     console.log("[Settings] Synced DB settings to local storage:", result.data);
     return { ok: true };
 }

--- a/src/services/setupService.js
+++ b/src/services/setupService.js
@@ -10,16 +10,7 @@ import { setTheme } from "../util/themes";
 
 export async function installationSetup() {
   storage.clearStorage();
-  storage.stats.init();
-  storage.operatingHours.init();
   setTheme("dark");
-  storage.shouldRedirect.set(true);
-  storage.redirection.toggle();
-  storage.list.set([]);
-  storage.uid.set("");
-  // Leave learning URL empty by default; user sets this in settings
-  storage.learningUri.set("");
-  storage.timeSettings.init();
   try {
     await browser.runtime.openOptionsPage();
   } catch (e) {
@@ -32,6 +23,5 @@ export async function installationSetup() {
 
 export async function setup() {
   intervals.intervalSetup();
-  storage.shouldRedirect.set(true);
   await redirection.start();
 }

--- a/src/util/storage.js
+++ b/src/util/storage.js
@@ -64,7 +64,7 @@ const activeSessionsStore = createKeyedStore("activeSessions");
  * @function
  * @description Clears all stored data in browser storage. */
 function clearStorage() {
-  storage.clear();
+  return storage.clear();
 }
 
 /**
@@ -73,10 +73,9 @@ function clearStorage() {
  * that determines whether or not a user should be redirected.
  * redirectionToggled is a settings parameter changed by the user. */
 
-function toggleRedirection() {
-  storage.get("toggled").then((data) => {
-    storage.set({ toggled: !data.toggled });
-  });
+async function toggleRedirection() {
+  const data = await storage.get("toggled");
+  await storage.set({ toggled: !data.toggled });
 }
 
 /**

--- a/src/util/storage.js
+++ b/src/util/storage.js
@@ -241,6 +241,9 @@ async function getDailyProgress() {
     "dailyProgressDate",
   ]);
   const today = getTodayKey();
+  if (dailyProgress === undefined && dailyProgressDate === undefined) {
+    return 0;
+  }
   if (dailyProgressDate !== today) {
     await storage.set({ dailyProgress: 0, dailyProgressDate: today });
     await setShouldRedirect(true);

--- a/src/values/messageTypeValues.js
+++ b/src/values/messageTypeValues.js
@@ -17,3 +17,5 @@ export const MESSAGE_API_UPDATE_LEARNING_URI = "api:updateLearningUri"
 export const MESSAGE_API_UPDATE_TIME_WASTING_SITE = "api:addTimeWastingSite"
 
 export const MESSAGE_API_REMOVE_TIME_WASTING_SITE = "api:removeTimeWastingSite"
+
+export const MESSAGE_REDIRECTION_REFRESH_FILTERS = "redirection:refreshFilters"


### PR DESCRIPTION
# Overview
This PR started as a fix for clearing local storage on sign-out. During *investigation*, I found out that several parts of the extension were not reading from storage at all, but were falling back to hardcoded default values defined in `defaultSettingValues.js`, which meant that clearing storage alone wasn't enough to guarantee a clean state (primarily for guest login).

Addresses issue #60.

> [!important]
> I've tried my best to test all different cases were it could go wrong. However, please try out some edge cases to see if everything is still working as intended.

# Changelog

### Storage reset on sign-out and guest login
`clearSessionLocally` now calls `storage.clearStorage()` to clear everything except for the theme, which should be dark by default. When signing in as a guest (or when `loadDefaults: true` is passed), it also writes the default settings explicitly into storage so the app always reads consistent values from the start.

### Default settings are now written on guest login
A new `loadDefaultSettingsLocally` function in `SetUser.svelte` writes operating hours, learning time, session duration, and reward time to storage using the default values, so the app never silently falls back to *'in-memory'* constants.

### Redirection is enabled correctly after login
When loading the extension for the first time, nothing is stored in local storage anymore. Now, after a successful login or guest sign-in, `shouldRedirect` is set to `true` and the redirection toggle is explicitly enabled.

### `clearStorage` is now awaitable
`storage.clearStorage()` previously called and forgot. It now returns a promise from `browser.storage.local.clear()` so callers can await it correctly.

### Installation setup simplified
Removed redundant explicit initialization calls from `installationSetup` and `setup` in `setupService.js`. Default values are now the responsibility of storage getters and the new `loadDefaultSettingsLocally` flow, avoiding double-initialisation.