### PR TITLE
Hide InviteCodeSettings for guest users

### DIFF
--- a/src/Pages/Components/Settings/SetRedirection.svelte
+++ b/src/Pages/Components/Settings/SetRedirection.svelte
@@ -26,6 +26,11 @@
   let hasSaved = false;
   let urlInputRef;
 
+  // Check if the user is a guest.
+  $: isGuestUser =
+    user === "guest" ||
+    user?.isGuest === true;
+
   onMount(async () => {
     try {
       learningUri = await storage.learningUri.get();
@@ -150,8 +155,10 @@
   <TimeSettings {user} />
   <hr />
   <OperatingHoursSettings {user} />
-  <hr />
-  <InviteCodeSettings />
+  {#if user && !isGuestUser}
+    <hr />
+    <InviteCodeSettings />
+  {/if}
   <hr />
   <h5>Other Settings:</h5>
   <div>


### PR DESCRIPTION
Currently the invite code input field are accessible for guests. This will cause issues as they don't have a required `jwt` which will be attached in the API request.

Now the invite code input field is gone if the user is a guest.

Addresses issue #67.