### PR TITLE
Fix: Race condition on increment for progress increment

### DIFF
--- a/src/services/TimerManager.js
+++ b/src/services/TimerManager.js
@@ -310,8 +310,7 @@ class TimerManager {
 
   // Start a learning session timer
   async startSessionTimer(durationMs, onComplete) {
-    // Session timers replace the daily learning interval; otherwise dailyProgress
-    // can advance from two intervals at once and appear to run too fast.
+    // Pause the daily timer while a session timer runs.
     if (this.learningTimeIntervalRef) {
       clearInterval(this.learningTimeIntervalRef);
       this.learningTimeIntervalRef = undefined;
@@ -378,8 +377,7 @@ class TimerManager {
 
   // Start session reward timer
   startSessionRewardTimer(durationMs, onComplete) {
-    // Reward timers should also pause the daily learning interval so the shared
-    // daily progress counter stays on a single 1-second cadence.
+    // Pause the daily timer while a session timer runs.
     if (this.learningTimeIntervalRef) {
       clearInterval(this.learningTimeIntervalRef);
       this.learningTimeIntervalRef = undefined;

--- a/src/services/TimerManager.js
+++ b/src/services/TimerManager.js
@@ -298,11 +298,6 @@ class TimerManager {
           if (!this.sessionCompleted) {
             this.sessionCompleted = true;
             
-            // Add 1-second buffer to compensate for checkActive() timing drift
-            this.dailyProgress += 1000;
-            await storage.dailyProgress.set(this.dailyProgress);
-            console.log("[Session] Added 1s timing buffer to daily progress");
-            
             if (typeof this.sessionOnComplete === "function") {
               this.sessionOnComplete();
               this.sessionOnComplete = null;

--- a/src/services/TimerManager.js
+++ b/src/services/TimerManager.js
@@ -315,6 +315,13 @@ class TimerManager {
 
   // Start a learning session timer
   async startSessionTimer(durationMs, onComplete) {
+    // Session timers replace the daily learning interval; otherwise dailyProgress
+    // can advance from two intervals at once and appear to run too fast.
+    if (this.learningTimeIntervalRef) {
+      clearInterval(this.learningTimeIntervalRef);
+      this.learningTimeIntervalRef = undefined;
+    }
+
     this.stopSessionTimer();
     this.stopSessionRewardTimer();
     
@@ -376,6 +383,13 @@ class TimerManager {
 
   // Start session reward timer
   startSessionRewardTimer(durationMs, onComplete) {
+    // Reward timers should also pause the daily learning interval so the shared
+    // daily progress counter stays on a single 1-second cadence.
+    if (this.learningTimeIntervalRef) {
+      clearInterval(this.learningTimeIntervalRef);
+      this.learningTimeIntervalRef = undefined;
+    }
+
     this.stopSessionTimer();
     this.stopSessionRewardTimer();
     


### PR DESCRIPTION
# Overview
Fixed a timing issue where the blocker overlay could appear to count time twice as fast as the learning overlay. The root cause was overlapping timer intervals updating the shared progress state. Session and reward timers now pause the daily learning interval before starting, and the extra end-of-session 1-second progress buffer was removed so timer accounting stays consistent.

Addresses issue #66.

# Changelogs
- Stopped the daily learning timer when session-based timers start to prevent duplicate progress updates.
- Applied the same timer isolation to reward timers so shared progress remains on a single cadence.
- Removed the extra 1-second completion buffer from session progress handling.