### PR TITLE
Use production API when signing extensions

### DIFF
--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - feature/use-prod-api
   workflow_dispatch:
 
 permissions:
@@ -27,6 +28,8 @@ jobs:
 
       - name: Build Chrome extension
         run: npm run build:chrome
+        env:
+          PUBLIC_API_BASE_URL: http://94.130.110.4/api/
 
       - name: Package Chrome extension
         run: |
@@ -59,6 +62,8 @@ jobs:
 
       - name: Build Firefox extension
         run: npm run build:firefox
+        env:
+          PUBLIC_API_BASE_URL: http://94.130.110.4/api/
 
       - name: Bump dev version
         run: node scripts/bump-dev-version.js

--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feature/use-prod-api
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: write
 
+env:
+  PUBLIC_API_BASE_URL: http://94.130.110.4/api/
+
 jobs:
   build_chrome:
     name: Build Chrome extension
@@ -28,7 +31,7 @@ jobs:
       - name: Build Chrome extension
         run: npm run build:chrome
         env:
-          PUBLIC_API_BASE_URL: http://94.130.110.4/api/
+          PUBLIC_API_BASE_URL: ${{ env.PUBLIC_API_BASE_URL }}
 
       - name: Package Chrome extension
         run: |
@@ -62,7 +65,7 @@ jobs:
       - name: Build Firefox extension
         run: npm run build:firefox
         env:
-          PUBLIC_API_BASE_URL: http://94.130.110.4/api/
+          PUBLIC_API_BASE_URL: ${{ env.PUBLIC_API_BASE_URL }}
 
       - name: Bump dev version
         run: node scripts/bump-dev-version.js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiki3",
-  "version": "3.3.1-beta0.1r",
+  "version": "3.3.1.001",
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiki3",
-  "version": "3.3.1.003",
+  "version": "3.3.1",
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiki3",
-  "version": "3.3.1.001",
+  "version": "3.3.1.003",
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiki3",
-  "version": "3.3.0",
+  "version": "3.3.1-beta0.1r",
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -51,5 +51,5 @@
     "extension_pages": "script-src 'self'; object-src 'self';"
   },
   "options_page": "index.html?page=settings",
-  "version": "3.3.1.002"
+  "version": "3.3.1"
 }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -11,9 +11,15 @@
   "icons": {
     "128": "images/AikiLogo.png"
   },
-  "permissions": ["storage", "tabs", "webNavigation"],
+  "permissions": [
+    "storage",
+    "tabs",
+    "webNavigation"
+  ],
   "background": {
-    "scripts": ["build/background.js"]
+    "scripts": [
+      "build/background.js"
+    ]
   },
   "action": {
     "default_title": "Aiki",
@@ -22,20 +28,28 @@
   },
   "content_scripts": [
     {
-      "matches": ["<all_urls>"],
-      "js": ["build/injection.js"],
+      "matches": [
+        "<all_urls>"
+      ],
+      "js": [
+        "build/injection.js"
+      ],
       "run_at": "document_start"
     }
   ],
   "web_accessible_resources": [
     {
-      "resources": ["images/AikiLogo.png"],
-      "matches": ["<all_urls>"]
+      "resources": [
+        "images/AikiLogo.png"
+      ],
+      "matches": [
+        "<all_urls>"
+      ]
     }
   ],
   "content_security_policy": {
     "extension_pages": "script-src 'self'; object-src 'self';"
   },
   "options_page": "index.html?page=settings",
-  "version": "3.2.0"
+  "version": "3.3.1.002"
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,7 +9,6 @@ import dotenv from 'dotenv';
 const production = !process.env.ROLLUP_WATCH;
 // Live reload is not compatible with extension pages (CSP + file scheme)
 const enableLiveReload = false;
-// Merge .env with runtime environment variables; runtime vars (e.g. CI) win.
 const env = {
   ...(dotenv.config().parsed || {}),
   ...process.env,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,7 +9,11 @@ import dotenv from 'dotenv';
 const production = !process.env.ROLLUP_WATCH;
 // Live reload is not compatible with extension pages (CSP + file scheme)
 const enableLiveReload = false;
-const env = dotenv.config().parsed || {};
+// Merge .env with runtime environment variables; runtime vars (e.g. CI) win.
+const env = {
+  ...(dotenv.config().parsed || {}),
+  ...process.env,
+};
 
 function serve() {
   let server;


### PR DESCRIPTION
The URL for the API in production has been added.
I also made a minor change to the way .env secrets are loaded into the Rollup configuration, as it was not working before.

I tested this by creating a beta release to test out if the extension was using the production api when getting signed.
You can test it out yourself by accessing the beta release [here](https://github.com/aiki-extension/Aiki3/releases/tag/untagged-ce9ab6adc766ee1ca7d4).

> [!NOTE]
> I think we should create a new release `3.3.2` when this gets approved, so we have a working production-ready extension for Firefox and Chrome. What are your throughts on this?