### PR TITLE
Feature/redirect prompt toggle

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -51,5 +51,5 @@
     "extension_pages": "script-src 'self'; object-src 'self';"
   },
   "options_page": "index.html?page=settings",
-  "version": "3.3.1"
+  "version": "3.3.2"
 }

--- a/src/Pages/Components/Settings/InviteCodeSettings.svelte
+++ b/src/Pages/Components/Settings/InviteCodeSettings.svelte
@@ -3,6 +3,7 @@
   import storage from "../../../util/storage";
   import { alertStore } from "../../../services/alertService";
   import { MESSAGE_API_UPDATE_INVITE_CODE } from "../../../values/messageTypeValues";
+  import { fetchAndSyncSettings } from "../../../services/settingsService";
 
   let inviteCode = "";
   let savedInviteCode = "";
@@ -23,6 +24,7 @@
       if (ok) {
         storage.inviteCode.set(inviteCode);
         savedInviteCode = inviteCode; // update the saved value on success
+        await fetchAndSyncSettings();
       } else {
         inviteCode = savedInviteCode; // revert the input
       }

--- a/src/Pages/Popup.svelte
+++ b/src/Pages/Popup.svelte
@@ -19,8 +19,9 @@
   });
 
   let origin = {};
-
-  let timeValues;
+  
+  // Ignore linter warning for this. Extension window breaks without this promise 
+  let timeValues = new Promise((resolve) => {});
 
   function sync(res) {
     timeValues = new Promise((resolve) => {

--- a/src/redirection.js
+++ b/src/redirection.js
@@ -671,6 +671,31 @@ function onContentScriptReady(tabId) {
 // changes between when the intent is queued and when it fires.
 async function dispatchPrompt(tabId, learningUri, procUrl) {
   const origin = await storage.origin.get();
+  const flags = await storage.featureFlags.get();
+  const promptEnabled = !flags.redirectPrompt;
+  console.log("promptEnabled is: " + promptEnabled);
+
+  if (!promptEnabled) {
+    // Skip prompt and instant redirect instead
+    addLearningSiteLoadedListener();
+    navigationGuards.install();
+    await SessionService.startSession(tabId, "learning", learningUri, procUrl);
+    await timer.startLearningSession();
+    storage.origin.set({ url: procUrl})
+    addOriginUpdatedListener(tabId);
+    await storage.globalPromptLock.remove();
+
+    try {
+      scheduleRevealOnLoad(tabId);
+      await browser.tabs.update(tabId, { url: learningUri });
+      setTimeout(() => triggerLearningOverlay(tabId), 1500);
+    } catch (error) {
+      l(error);
+    }
+    return; // Exits early to dismiss prompt
+    
+  }
+
   if (origin) {
     renderContentBlocker({ tabId, frameId: 0, url: procUrl });
   } else {

--- a/src/redirection.js
+++ b/src/redirection.js
@@ -277,6 +277,24 @@ async function redirect(details, immediate = false) {
   }
 }
 
+async function redirectTo(tabId, learningUri, procUrl) {
+    addLearningSiteLoadedListener();
+    navigationGuards.install();
+    await SessionService.startSession(tabId, "learning", learningUri, procUrl);
+    await timer.startLearningSession();
+    storage.origin.set({ url: procUrl})
+    addOriginUpdatedListener(tabId);
+    await storage.globalPromptLock.remove();
+
+    try {
+      scheduleRevealOnLoad(tabId);
+      await browser.tabs.update(tabId, { url: learningUri });
+      setTimeout(() => triggerLearningOverlay(tabId), 1500);
+    } catch (error) {
+      l(error);
+    }
+}
+
 async function checkActiveTime() {
   const fromTime = await storage.operatingHours.from.get();
   const toTime = await storage.operatingHours.to.get();
@@ -674,26 +692,10 @@ async function dispatchPrompt(tabId, learningUri, procUrl) {
   const flags = await storage.featureFlags.get();
   const promptEnabled = !flags.redirectPrompt;
   console.log("promptEnabled is: " + promptEnabled);
-
   if (!promptEnabled) {
     // Skip prompt and instant redirect instead
-    addLearningSiteLoadedListener();
-    navigationGuards.install();
-    await SessionService.startSession(tabId, "learning", learningUri, procUrl);
-    await timer.startLearningSession();
-    storage.origin.set({ url: procUrl})
-    addOriginUpdatedListener(tabId);
-    await storage.globalPromptLock.remove();
-
-    try {
-      scheduleRevealOnLoad(tabId);
-      await browser.tabs.update(tabId, { url: learningUri });
-      setTimeout(() => triggerLearningOverlay(tabId), 1500);
-    } catch (error) {
-      l(error);
-    }
-    return; // Exits early to dismiss prompt
-    
+    redirectTo(tabId, learningUri, procUrl);
+    return;
   }
 
   if (origin) {
@@ -724,24 +726,7 @@ async function promptRedirect(tabId, url, originUrl) {
       await SessionService.startSession(tabId, "procrastination", originUrl);
     },
     onAccept: async () => {
-      addLearningSiteLoadedListener();
-      navigationGuards.install();
-      await SessionService.startSession(tabId, "learning", url, originUrl);
-      await timer.startLearningSession();
-      storage.origin.set({ url: originUrl, tabId: tabId });
-      addOriginUpdatedListener(tabId);
-
-      // Clears the global prompt lock when user accepts
-      await storage.globalPromptLock.remove();
-      try {
-        scheduleRevealOnLoad(tabId);
-        await browser.tabs.update(tabId, {
-          url: url,
-        });
-        setTimeout(() => triggerLearningOverlay(tabId), 1500);
-      } catch (error) {
-        l(error);
-      }
+      redirectTo(tabId, url, originUrl);
     },
   });
 }

--- a/src/services/settingsService.js
+++ b/src/services/settingsService.js
@@ -18,6 +18,7 @@ async function syncDBSettingsToLocalStorage(db) {
         storage.operatingHours.to.set({ hrs: Math.floor(db.operatingEndMinutes / 60), min: db.operatingEndMinutes % 60 }),
         storage.learningUri.set(db.learningSiteDomain || ""),
         storage.list.set((db.timeWastingSites || []).map(domain => parseUrl(domain))), // Stores time-wasting sites into local storage
+        storage.featureFlags.set(db.flags ?? {}), 
     ])
 }
 

--- a/src/util/storage.js
+++ b/src/util/storage.js
@@ -278,6 +278,15 @@ async function getRewardUnlock() {
   return typeof rewardUnlockAt === "number" ? rewardUnlockAt : 0;
 }
 
+function setFeatureFlags(flags) {
+  storage.set({ featureFlags: flags ?? {} });
+}
+
+async function getFeatureFlags() {
+  const result = await storage.get("featureFlags");
+  return result && typeof result.featureFlags === "object" ? result.featureFlags: {};
+}
+
 /**
  * @description Initializes the time settings in storage upon app installation. */
 function userTimeInit() {
@@ -688,6 +697,10 @@ export default {
     get: activeSessionsStore.get,
     remove: activeSessionsStore.remove,
     clear: activeSessionsStore.clear,
+  },
+  featureFlags: {
+    get: getFeatureFlags,
+    set: setFeatureFlags,
   },
   forgetOrigin: () => storage.remove("origin"),
 };


### PR DESCRIPTION
# Pull Request Summary

This release focuses on bringing feature flag functionality for the redirect prompt to the frontend. When the user sets "REDIRECT-CODE" as their invite code, the redirect prompt is toggled off and instant redirect is enabled instead. The code is subject to change to a more proper code (which is done in the backend)

To properly test it you will need to use the [Backend PR branch](https://github.com/aiki-extension/Aiki3-Backend/pull/12) and set an invite code called "REDIRECT-CODE" through Prisma Studio by the way. 

---

## What's New

### Feature Flags
Dynamic feature toggling is now supported across the extension. Feature flags are fetched from the backend and stored locally, enabling features to be enabled or disabled.

- Added `get` and `set` methods for `featureFlags` in `src/util/storage.js`
- Flags are synced from the database to local storage via `src/services/settingsService.js`
- Redirect logic in `src/redirection.js` now checks the `redirectPrompt` flag — when disabled, the prompt is skipped and an instant redirect occurs

---

### Code Simplification
Duplicate redirect logic has been cleaned up by extracting it into a shared `redirectTo` function, used by both `promptRedirect` and `dispatchPrompt` in `src/redirection.js`. This was needed as the core redirect logic was now used to have instant redirection. So a helper function was created to reduce the redundancy otherwise created.

---

### Settings Synchronization
After updating an invite code in `InviteCodeSettings.svelte`, the extension now immediately fetches and syncs the latest settings.

### Bug fix
It was discovered that after the linter had been ran, you wouldn't be able to open the extension window to go to the settings page. The linter had tagged one part of the code containing a "promise" as code that was unused. This turned out to be false and has now been reverted
