### PR TITLE
Update/remove tld auto prepend

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -51,5 +51,5 @@
     "extension_pages": "script-src 'self'; object-src 'self';"
   },
   "options_page": "index.html?page=settings",
-  "version": "3.3.1"
+  "version": "3.3.2"
 }

--- a/src/Pages/Components/Settings/SetRedirection.svelte
+++ b/src/Pages/Components/Settings/SetRedirection.svelte
@@ -53,7 +53,7 @@
         isEditing = true;
         alertStore.add({ type: 'success', message: 'Learning platform cleared.' });
       } else {
-        alertStore.add({ type: 'warning', message: 'Invalid URL. Remember to include a tld (.com, .org, .dk etc.)' });
+        alertStore.add({ type: 'warning', message: 'Invalid URL. Remember to include a domain ending (.com, .org, .dk etc.)' });
       }
       return;
     }

--- a/src/Pages/Components/Settings/SetRedirection.svelte
+++ b/src/Pages/Components/Settings/SetRedirection.svelte
@@ -53,7 +53,7 @@
         isEditing = true;
         alertStore.add({ type: 'success', message: 'Learning platform cleared.' });
       } else {
-        alertStore.add({ type: 'warning', message: 'Invalid URL.' });
+        alertStore.add({ type: 'warning', message: 'Invalid URL. Remember to include a tld (.com, .org, .dk etc.)' });
       }
       return;
     }

--- a/src/Pages/Components/Settings/SetTimeWastingSites.svelte
+++ b/src/Pages/Components/Settings/SetTimeWastingSites.svelte
@@ -113,7 +113,7 @@
     if (!normalized) {
       alertStore.add({
         type: 'warning',
-        message: 'Invalid URL format!'
+        message: 'Invalid URL. Remember to include a tld (.com, .org, .dk etc.)'
       })
       return;
     }

--- a/src/Pages/Components/Settings/SetTimeWastingSites.svelte
+++ b/src/Pages/Components/Settings/SetTimeWastingSites.svelte
@@ -113,7 +113,7 @@
     if (!normalized) {
       alertStore.add({
         type: 'warning',
-        message: 'Invalid URL. Remember to include a tld (.com, .org, .dk etc.)'
+        message: 'Invalid URL. Remember to include a domain ending (.com, .org, .dk etc.)'
       })
       return;
     }

--- a/src/Pages/Components/Settings/SetTimeWastingSites.svelte
+++ b/src/Pages/Components/Settings/SetTimeWastingSites.svelte
@@ -123,7 +123,7 @@
 
     learningUri = parseUrl(await storage.learningUri.get())
     let site = parseUrl(addItemValue);
-    
+    site.host = normalized;
     
     if (learningUri.name === site.name) {
       alertStore.add({

--- a/src/util/utilities.js
+++ b/src/util/utilities.js
@@ -80,13 +80,7 @@ export function normalizeUrl(input) {
   const domainPart = match[1];
   const pathPart = match[2] || ''; // Web paths
 
-  const host = trimmed.includes('://') || trimmed.startsWith('www.') 
-    ? trimmed.split('/')[0] 
-    : `www.${domainPart}`;
-
-  const normalizedHost = host.startsWith('www.') ? host : `www.${host}`;
-  
-  return normalizedHost + pathPart;
+  return `www.${domainPart}${pathPart}`;
 }
 
 export function makeDate() {

--- a/src/util/utilities.js
+++ b/src/util/utilities.js
@@ -67,12 +67,21 @@ export function parseUrl(site) {
 
 export function normalizeUrl(input) {
   if (!input?.trim()) return null;
-  const { host } = parseUrl(input);
-  if (!host) return null;
+
+  const trimmed = input.trim();
+
   const urlPattern =
-    /(?:https?:\/\/)?(?:www\.)?([a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.[a-zA-Z]{2,})(?:[/?#].*)?$/;
-  const match = host.match(urlPattern);
+    /^(?:https?:\/\/)?(?:www\.)?([a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.[a-zA-Z]{2,})(?:[/?#].*)?$/;
+    
+  const match = trimmed.match(urlPattern);
   if (!match) return null;
+
+  // Extracts only the domain part and validates
+  const domainPart = match[1];
+  const host = trimmed.includes('://') || trimmed.startsWith('www.') 
+    ? trimmed.split('/')[0] 
+    : `www.${domainPart}`;
+
   return host.startsWith('www.') ? host : `www.${host}`;
 }
 

--- a/src/util/utilities.js
+++ b/src/util/utilities.js
@@ -71,18 +71,22 @@ export function normalizeUrl(input) {
   const trimmed = input.trim();
 
   const urlPattern =
-    /^(?:https?:\/\/)?(?:www\.)?([a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.[a-zA-Z]{2,})(?:[/?#].*)?$/;
+    /^(?:https?:\/\/)?(?:www\.)?([a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.[a-zA-Z]{2,})(\/.*)?$/;
     
   const match = trimmed.match(urlPattern);
   if (!match) return null;
 
   // Extracts only the domain part and validates
   const domainPart = match[1];
+  const pathPart = match[2] || ''; // Web paths
+
   const host = trimmed.includes('://') || trimmed.startsWith('www.') 
     ? trimmed.split('/')[0] 
     : `www.${domainPart}`;
 
-  return host.startsWith('www.') ? host : `www.${host}`;
+  const normalizedHost = host.startsWith('www.') ? host : `www.${host}`;
+  
+  return normalizedHost + pathPart;
 }
 
 export function makeDate() {


### PR DESCRIPTION
## Intro
Beforehand the normalization would prepend ".com" as the TLD for the url. This was an issue since if a user tried to write "dr.dk" then it would turn into "dr.com". It also would not include webpaths into the url, so the user couldn't set "www.zeeguu.org/exercises" specifically as their learning url. This PR addresses these two issues

## Changes
- Normalization no longer prepends .com as the standard TLD. It instead requires the user to input an TLD into their given url (changed the alert to reflect this)
- Normalization now also includes webpaths in the url