### PR TITLE
Use HTTPS version of API

### DIFF
--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -10,7 +10,7 @@ permissions:
   contents: write
 
 env:
-  PUBLIC_API_BASE_URL: http://94.130.110.4/api/
+  PUBLIC_API_BASE_URL: https://zeeguu.dev/api/
 
 jobs:
   build_chrome:

--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -10,7 +10,7 @@ permissions:
   contents: write
 
 env:
-  PUBLIC_API_BASE_URL: https://zeeguu.dev/api/
+  PUBLIC_API_BASE_URL: https://aiki.zeeguu.dev/api/
 
 jobs:
   build_chrome:


### PR DESCRIPTION
Updates the `PUBLIC_API_BASE_URL` environment variable in the GitHub Actions workflow configuration to use a secure HTTPS endpoint.

Backend task: https://github.com/aiki-extension/Aiki3-Backend/pull/16