### PR TITLE
Bug/feature flag working on reward time

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -11,9 +11,15 @@
   "icons": {
     "128": "images/AikiLogo.png"
   },
-  "permissions": ["storage", "tabs", "webNavigation"],
+  "permissions": [
+    "storage",
+    "tabs",
+    "webNavigation"
+  ],
   "background": {
-    "scripts": ["build/background.js"]
+    "scripts": [
+      "build/background.js"
+    ]
   },
   "action": {
     "default_title": "Aiki",
@@ -22,20 +28,28 @@
   },
   "content_scripts": [
     {
-      "matches": ["<all_urls>"],
-      "js": ["build/injection.js"],
+      "matches": [
+        "<all_urls>"
+      ],
+      "js": [
+        "build/injection.js"
+      ],
       "run_at": "document_start"
     }
   ],
   "web_accessible_resources": [
     {
-      "resources": ["images/AikiLogo.png"],
-      "matches": ["<all_urls>"]
+      "resources": [
+        "images/AikiLogo.png"
+      ],
+      "matches": [
+        "<all_urls>"
+      ]
     }
   ],
   "content_security_policy": {
     "extension_pages": "script-src 'self'; object-src 'self';"
   },
   "options_page": "index.html?page=settings",
-  "version": "3.3.2"
+  "version": "4.0.0"
 }

--- a/src/handlers/messageHandler.js
+++ b/src/handlers/messageHandler.js
@@ -261,22 +261,7 @@ export async function handleMessage(message, sender) {
                   '[Session] On time wasting site, showing redirect prompt',
                 );
 
-                // Show redirect prompt
-                const response = await browser.tabs.sendMessage(tabs[0].id, {
-                  action: 'display:redirectPrompt',
-                  url: learningUrl,
-                  originUrl: timeWastingUrl,
-                });
-
-                // If user clicks "Redirect", navigate to learning site
-                if (response && response.action === 'redirect') {
-                  console.log('[Session] User chose to redirect to learning');
-                  await browser.tabs.update(tabs[0].id, { url: learningUrl });
-                } else {
-                  console.log(
-                    '[Session] User chose to stay on time wasting site',
-                  );
-                }
+                await redirection.dispatchPrompt(tabs[0].id, learningUrl, currentUrl);
               } else if (isOnLearningSite(currentUrl, learningUrl)) {
                 console.log('[Session] On learning site, starting new session');
                 // Trigger session start on learning site

--- a/src/handlers/messageHandler.js
+++ b/src/handlers/messageHandler.js
@@ -260,7 +260,7 @@ export async function handleMessage(message, sender) {
                 console.log(
                   '[Session] On time wasting site, showing redirect prompt',
                 );
-
+                await storage.origin.remove(); // clear stale origin so dispatchPrompt uses promptRedirect
                 await redirection.dispatchPrompt(tabs[0].id, learningUrl, currentUrl);
               } else if (isOnLearningSite(currentUrl, learningUrl)) {
                 console.log('[Session] On learning site, starting new session');

--- a/src/redirection.js
+++ b/src/redirection.js
@@ -846,4 +846,5 @@ export default {
   checkActiveTab,
   finalizeAllActiveSessions,
   onContentScriptReady,
+  dispatchPrompt,
 };


### PR DESCRIPTION
## Summary
When implementing feature flags, one edge case wasn't discovered. When the reward time ended and you had the redirect prompt turned off, it wouldn't instant redirect upon finishing. This turned out to be because this specific place in the code, didn't use `dispatchPrompt` from `redirection.js` (which is what specifically is turned off with the feature toggle). This PR refactors such that this function is also used when reward time has ended