### PR TITLE
Run linter and prettier check on all branches

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -2,7 +2,6 @@ name: Lint & Format
 
 on:
   pull_request:
-    branches: [main]
 
 jobs:
   lint:


### PR DESCRIPTION
This will avoid making a separate commit in sprint branches for fixing lint and formatting errors - and hence minimizing last-minute errors before merging to main :)