### PR TITLE
Remove unused reactive block for siteName

### DIFF
--- a/src/Pages/Popup.svelte
+++ b/src/Pages/Popup.svelte
@@ -4,7 +4,6 @@
  -->
 <script>
   /* Functional and module imports */
-  import { parseUrl } from "../util/utilities";
   import storage from "../util/storage";
   import browser from "webextension-polyfill";
 
@@ -49,11 +48,6 @@
     origin = await storage.origin.get();
   }
 
-  $: if (origin) {
-    if (origin.url) {
-      siteName = parseUrl(origin.url).name;
-    }
-  }
   setup();
 </script>
 


### PR DESCRIPTION
The root cause was dead code left over from a previous refactor.

`ContinueButton.svelte` used to accept a `siteName` prop (`export let siteName`), so `Popup.svelte` had a reactive block that computed it from the current URL and passed it down.
At some point the `siteName` was commented out in `ContinueButton`, but the code `Popup.svelte` that computed it was not cleaned up.

The fix was to just clean up the 'old code':
```js
  $: if (origin) {
    if (origin.url) {
      siteName = parseUrl(origin.url).name;
    }
  }
```