### PR TITLE
Removed redundant strategy const

### DIFF
--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -189,7 +189,6 @@ This one is worth testing carefully since the behaviour is not immediately obvio
 
 ---
 
-
 ## 4. Multi-tab and window edge cases
 
 ### 4a. Switching browser windows during a session

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -189,17 +189,6 @@ This one is worth testing carefully since the behaviour is not immediately obvio
 
 ---
 
-### 3d. What happens at midnight (known unknown)
-
-**Context:** The daily progress resets inside `getDailyProgress()` when the stored `dailyProgressDate` doesn't match today's date string. This check only fires when something actually calls `getDailyProgress()`, which includes `startSessionTimer()`, `decrementSession()`, and `syncDailyState()`.
-
-**What this means in practice:** If a session is running across midnight, `decrementSession()` increments `dailyProgress` by calling `storage.dailyProgress.set()` directly with the in-memory value, it does NOT go through `getDailyProgress()`. So the reset probably does not happen mid-session. The timer in memory just keeps going.
-
-The next call to `getDailyProgress()` after midnight (which would happen when a new session tries to start, or on the next popup poll) should trigger the reset and return 0, treating it as a fresh day.
-
-**To test:** This is genuinely hard to reproduce without waiting until midnight or mocking the system clock. What you can do is manually set `dailyProgressDate` in extension storage to yesterday's date string (e.g. `"Mon Apr 28 2025"`) and then trigger a new session. The reset should fire and `dailyProgress` should go back to 0.
-
----
 
 ## 4. Multi-tab and window edge cases
 

--- a/src/redirection.js
+++ b/src/redirection.js
@@ -7,7 +7,7 @@ import { createRedirectFlow } from './redirection/redirectFlow';
 import { createActiveTabCheck } from './redirection/activeTabCheck';
 import { createListeners } from './redirection/listeners';
 
-const navigationGuards = new NavigationGuards(false);
+const navigationGuards = new NavigationGuards();
 const promptControl = createPromptControl({ navigationGuards });
 
 const learningResource = createLearningResource({
@@ -38,17 +38,9 @@ const restoreFlow = createRestoreFlow({
 });
 const { gotoOrigin } = restoreFlow;
 
-// Was previously used to select between different redirection strategies (e.g. controlled vs experimental variants).
-// todo: Refactor to not support multiple strategies in the same codebase, as this adds unnecessary complexity and indirection. If we want to run experiments, we can use feature flags and conditionals within a single strategy implementation.
-const strategy = {
-  handleNavigation: async () => false,
-  onLearningSiteNavigation: async () => {},
-};
-
 const redirectFlow = createRedirectFlow({
   navigationGuards,
   promptControl,
-  strategy,
   addLearningSiteLoadedListener,
   addOriginUpdatedListener,
   removeOriginUpdatedListener,

--- a/src/redirection/redirectFlow.js
+++ b/src/redirection/redirectFlow.js
@@ -125,11 +125,6 @@ export function createRedirectFlow({
           return;
         }
 
-        const timeWasteHosts = (timeWasteList || [])
-          .map((item) => item?.host || item?.name || '')
-          .filter(Boolean);
-        const learningUrl = await getLearningUrl();
-
         let shouldRedirect = await storage.shouldRedirect.get();
         if (!shouldRedirect) {
           const unlockAt = await storage.rewardUnlock.get();

--- a/src/redirection/redirectFlow.js
+++ b/src/redirection/redirectFlow.js
@@ -23,7 +23,6 @@ import { isTrackedTimeWastingUrl } from './shared/siteFilter';
  * @param {object} deps
  * @param {object} deps.navigationGuards
  * @param {object} deps.promptControl
- * @param {{ handleNavigation: Function }} deps.strategy
  * @param {() => Promise<void>} deps.addLearningSiteLoadedListener
  * @param {() => void} deps.addOriginUpdatedListener
  * @param {() => void} deps.removeOriginUpdatedListener
@@ -33,7 +32,6 @@ import { isTrackedTimeWastingUrl } from './shared/siteFilter';
 export function createRedirectFlow({
   navigationGuards,
   promptControl,
-  strategy,
   addLearningSiteLoadedListener,
   addOriginUpdatedListener,
   removeOriginUpdatedListener,
@@ -131,16 +129,6 @@ export function createRedirectFlow({
           .map((item) => item?.host || item?.name || '')
           .filter(Boolean);
         const learningUrl = await getLearningUrl();
-
-        const handled = await strategy.handleNavigation(details, {
-          applyPreemptiveHide: (tabId) =>
-            navigationGuards.applyPreemptiveHide(tabId),
-          removePreemptiveHide: (tabId) =>
-            navigationGuards.removePreemptiveHide(tabId),
-          timeWastingHosts: timeWasteHosts,
-          learningUrl,
-        });
-        if (handled) return;
 
         let shouldRedirect = await storage.shouldRedirect.get();
         if (!shouldRedirect) {

--- a/src/services/NavigationGuards.js
+++ b/src/services/NavigationGuards.js
@@ -4,16 +4,8 @@ import siteDetector from './siteDetector';
 import storage from '../util/storage';
 import PreemptiveHide from './PreemptiveHide';
 
-/**
- * NavigationGuards centralizes tab/window listeners and delegates session handling.
- * A strategy object must be provided with:
- * - handleNavigation(tabId, url): boolean (true if handled)
- * - handleTabClose?(tabId): optional async hook
- * - onLearningSiteNavigation?(details): optional async hook
- */
 class NavigationGuards {
-  constructor(strategy) {
-    this.strategy = strategy;
+  constructor() {
     this.lastActiveTabByWindow = new Map();
     this.timeWastingGuardsRegistered = false;
     this.onActivatedHandler = null;
@@ -190,16 +182,8 @@ class NavigationGuards {
     browser.tabs.onActivated.addListener(this.onActivatedHandler);
 
     this.onRemovedHandler = async (tabId, removeInfo) => {
-      if (this.strategy?.handleTabClose) {
-        await this.strategy.handleTabClose(tabId);
-      } else {
-        await SessionService.finalizeSession(
-          tabId,
-          'timeWasting',
-          'tab_closed',
-        );
-        await SessionService.finalizeSession(tabId, 'learning', 'tab_closed');
-      }
+      await SessionService.finalizeSession(tabId, 'timeWasting', 'tab_closed');
+      await SessionService.finalizeSession(tabId, 'learning', 'tab_closed');
 
       if (removeInfo?.windowId !== undefined) {
         const tracked = this.lastActiveTabByWindow.get(removeInfo.windowId);
@@ -229,9 +213,6 @@ class NavigationGuards {
         details.tabId,
         this.hideImmediatePrompt.bind(this),
       );
-      if (this.strategy?.onLearningSiteNavigation && details.url) {
-        await this.strategy.onLearningSiteNavigation(details);
-      }
     };
     browser.webNavigation.onCommitted.addListener(this.onCommittedHandler);
 


### PR DESCRIPTION
Strategy is a dead end as we use feature flags instead of redirection strategies. Remainder from the larger refactor.

- `redirection.js`: removed the strategy stub object and its comment; removed strategy from the createRedirectFlow call. Changed new NavigationGuards(false) to new NavigationGuards().
- `redirectFlow.js`: removed strategy from the function signature and JSDoc. Removed the strategy.handleNavigation() call and the unreachable if (handled) return guard.
- `NavigationGuards.js`: removed the strategy JSDoc block, the constructor parameter, and this.strategy. else-body becomes the unconditional path. removed the dead onLearningSiteNavigation hook.