### PR TITLE
Fix overlay and session tracking on direct learning site navigation

### DIFF
--- a/src/Pages/Popup.svelte
+++ b/src/Pages/Popup.svelte
@@ -4,7 +4,6 @@
  -->
 <script>
   /* Functional and module imports */
-  import storage from "../util/storage";
   import browser from "webextension-polyfill";
 
   /* Components import */
@@ -17,7 +16,6 @@
   name: "Popup Communication",
   });
 
-  let origin = {};
   
   // Ignore linter warning for this. Extension window breaks without this promise 
   let timeValues = new Promise((resolve) => {}); // eslint-disable-line
@@ -44,11 +42,7 @@
     }
   }, 1000);
 
-  async function setup() {
-    origin = await storage.origin.get();
-  }
 
-  setup();
 </script>
 
 <main>

--- a/src/handlers/messageHandler.js
+++ b/src/handlers/messageHandler.js
@@ -51,8 +51,8 @@ export async function handleMessage(message, sender) {
   if (message.type === 'learning:autoStart') {
     return (async () => {
       try {
-        // SessionService decides: direct-nav tab -> voluntary learning, redirected tab -> full session.
-        if (await SessionService.maybeStartVoluntaryLearning(sender?.tab?.id)) {
+        if (await SessionService.checkVoluntaryLearning(sender?.tab?.id)) {
+          SessionService.startVoluntaryLearning(sender?.tab?.id);
           return { redirected: false };
         }
         // Stop any voluntary tracking for this tab when full redirect session takes over

--- a/src/handlers/messageHandler.js
+++ b/src/handlers/messageHandler.js
@@ -56,7 +56,7 @@ export async function handleMessage(message, sender) {
           return { redirected: false };
         }
         // Stop any voluntary tracking for this tab when full redirect session takes over
-        SessionService.stopVoluntaryLearning(sender?.tab?.id);
+        SessionService.stopVoluntaryLearning();
 
         // Get information on the daily goal
         const dailyGoal = parseTime.toSystem(

--- a/src/handlers/messageHandler.js
+++ b/src/handlers/messageHandler.js
@@ -50,10 +50,12 @@ export async function handleMessage(message, sender) {
   if (message.type === 'learning:autoStart') {
     return (async () => {
       try {
-        // Only start a session if the user arrived via a redirect (origin is set).
-        // Direct navigation to the learning site should not count time or show the overlay.
+        // Only start a session if the user arrived via a redirect (origin is set
+        // and its tabId matches the sender tab). A tab-ID mismatch means either
+        // a direct navigation or the original learning tab was closed and origin
+        // was retained for content-blocker purposes only.
         const existingOrigin = await storage.origin.get();
-        if (!existingOrigin) {
+        if (!existingOrigin || existingOrigin.tabId !== sender?.tab?.id) {
           return { redirected: false };
         }
 

--- a/src/handlers/messageHandler.js
+++ b/src/handlers/messageHandler.js
@@ -97,10 +97,11 @@ export async function handleMessage(message, sender) {
         // was retained for content-blocker purposes only.
         const existingOrigin = await storage.origin.get();
         if (!existingOrigin || existingOrigin.tabId !== sender?.tab?.id) {
-          if (sender?.tab?.id !== undefined) startPassiveLearning(sender.tab.id);
+          if (sender?.tab?.id !== undefined)
+            startPassiveLearning(sender.tab.id);
           return { redirected: false };
         }
-        // Stop any passive tracking for this tab when full redirect session takes over 
+        // Stop any passive tracking for this tab when full redirect session takes over
         stopPassiveLearning(sender?.tab?.id);
 
         // Get information on the daily goal

--- a/src/handlers/messageHandler.js
+++ b/src/handlers/messageHandler.js
@@ -55,9 +55,6 @@ export async function handleMessage(message, sender) {
           await SessionService.startVoluntaryLearning(sender?.tab?.id);
           return { redirected: false };
         }
-        // Stop any voluntary tracking for this tab when full redirect session takes over
-        SessionService.stopVoluntaryLearning();
-
         // Get information on the daily goal
         const dailyGoal = parseTime.toSystem(
           await storage.timeSettings.learningTime.get(),

--- a/src/handlers/messageHandler.js
+++ b/src/handlers/messageHandler.js
@@ -128,6 +128,11 @@ export async function handleMessage(message, sender) {
           } else {
             console.log('[Session] Session already running with same duration');
           }
+        } else if (timer.isSessionPaused()) {
+          // Resume a session that was paused when the previous learning tab closed
+          timer.resumeSessionTimer(() => {
+            console.log('[Session] Session complete!');
+          });
         } else {
           // Caps session if remaining of daily goal is lower than set session amount
           const dailyGoal = parseTime.toSystem(

--- a/src/handlers/messageHandler.js
+++ b/src/handlers/messageHandler.js
@@ -50,15 +50,11 @@ export async function handleMessage(message, sender) {
   if (message.type === 'learning:autoStart') {
     return (async () => {
       try {
-        // Ensure we have an origin set when user navigates directly to the learning site
-        if (sender?.tab?.id) {
-          const existingOrigin = await storage.origin.get();
-          if (!existingOrigin) {
-            await storage.origin.set({
-              url: 'https://www.reddit.com',
-              tabId: sender.tab.id,
-            });
-          }
+        // Only start a session if the user arrived via a redirect (origin is set).
+        // Direct navigation to the learning site should not count time or show the overlay.
+        const existingOrigin = await storage.origin.get();
+        if (!existingOrigin) {
+          return { redirected: false };
         }
 
         // Get information on the daily goal

--- a/src/handlers/messageHandler.js
+++ b/src/handlers/messageHandler.js
@@ -4,7 +4,8 @@ import browser from 'webextension-polyfill';
 import { parseTime } from '../util/utilities';
 import { handleApiMessage } from './apiHandler';
 import redirection from '../redirection';
-import { getLearningUrl, isLearningSite } from '../services/siteDetector';
+import { getLearningUrl } from '../services/siteDetector';
+import SessionService from '../services/SessionService';
 import { MESSAGE_REDIRECTION_REFRESH_FILTERS } from '../values/messageTypeValues';
 
 /*
@@ -12,47 +13,6 @@ This module handles incoming messages from content scripts and other parts of th
 It processes different message types, such as timer requests, learning session management.
 Auth messages are delegated to apiHandler.
 */
-
-// Tracks direct-navigation learning tabs and ticks dailyProgress in real time.
-const passiveLearningTabs = new Map(); // tabId -> removeListeners
-
-function stopPassiveLearning(tabId) {
-  const removeListeners = passiveLearningTabs.get(tabId);
-  if (!removeListeners) return;
-  passiveLearningTabs.delete(tabId);
-  removeListeners();
-}
-
-function startPassiveLearning(tabId) {
-  if (passiveLearningTabs.has(tabId)) return;
-
-  const intervalRef = setInterval(() => {
-    storage.dailyProgress
-      .get()
-      .then((current) => storage.dailyProgress.set((current || 0) + 1000))
-      .catch(() => {});
-  }, 1000);
-
-  function onRemoved(closedTabId) {
-    if (closedTabId === tabId) stopPassiveLearning(tabId);
-  }
-
-  async function onUpdated(updatedTabId, changeInfo) {
-    if (updatedTabId !== tabId || !changeInfo.url) return;
-    const learningUri = await getLearningUrl();
-    if (learningUri && isLearningSite(changeInfo.url, learningUri)) return;
-    stopPassiveLearning(tabId);
-  }
-
-  browser.tabs.onRemoved.addListener(onRemoved);
-  browser.tabs.onUpdated.addListener(onUpdated);
-
-  passiveLearningTabs.set(tabId, () => {
-    clearInterval(intervalRef);
-    browser.tabs.onRemoved.removeListener(onRemoved);
-    browser.tabs.onUpdated.removeListener(onUpdated);
-  });
-}
 
 export async function handleMessage(message, sender) {
   if (!message || typeof message !== 'object') {
@@ -91,18 +51,12 @@ export async function handleMessage(message, sender) {
   if (message.type === 'learning:autoStart') {
     return (async () => {
       try {
-        // Only start a session if the user arrived via a redirect (origin is set
-        // and its tabId matches the sender tab). A tab-ID mismatch means either
-        // a direct navigation or the original learning tab was closed and origin
-        // was retained for content-blocker purposes only.
-        const existingOrigin = await storage.origin.get();
-        if (!existingOrigin || existingOrigin.tabId !== sender?.tab?.id) {
-          if (sender?.tab?.id !== undefined)
-            startPassiveLearning(sender.tab.id);
+        // SessionService decides: direct-nav tab -> voluntary learning, redirected tab -> full session.
+        if (await SessionService.maybeStartVoluntaryLearning(sender?.tab?.id)) {
           return { redirected: false };
         }
-        // Stop any passive tracking for this tab when full redirect session takes over
-        stopPassiveLearning(sender?.tab?.id);
+        // Stop any voluntary tracking for this tab when full redirect session takes over
+        SessionService.stopVoluntaryLearning(sender?.tab?.id);
 
         // Get information on the daily goal
         const dailyGoal = parseTime.toSystem(

--- a/src/handlers/messageHandler.js
+++ b/src/handlers/messageHandler.js
@@ -4,7 +4,7 @@ import browser from 'webextension-polyfill';
 import { parseTime } from '../util/utilities';
 import { handleApiMessage } from './apiHandler';
 import redirection from '../redirection';
-import { getLearningUrl } from '../services/siteDetector';
+import { getLearningUrl, isLearningSite } from '../services/siteDetector';
 import { MESSAGE_REDIRECTION_REFRESH_FILTERS } from '../values/messageTypeValues';
 
 /*
@@ -12,6 +12,47 @@ This module handles incoming messages from content scripts and other parts of th
 It processes different message types, such as timer requests, learning session management.
 Auth messages are delegated to apiHandler.
 */
+
+// Tracks direct-navigation learning tabs and ticks dailyProgress in real time.
+const passiveLearningTabs = new Map(); // tabId -> removeListeners
+
+function stopPassiveLearning(tabId) {
+  const removeListeners = passiveLearningTabs.get(tabId);
+  if (!removeListeners) return;
+  passiveLearningTabs.delete(tabId);
+  removeListeners();
+}
+
+function startPassiveLearning(tabId) {
+  if (passiveLearningTabs.has(tabId)) return;
+
+  const intervalRef = setInterval(() => {
+    storage.dailyProgress
+      .get()
+      .then((current) => storage.dailyProgress.set((current || 0) + 1000))
+      .catch(() => {});
+  }, 1000);
+
+  function onRemoved(closedTabId) {
+    if (closedTabId === tabId) stopPassiveLearning(tabId);
+  }
+
+  async function onUpdated(updatedTabId, changeInfo) {
+    if (updatedTabId !== tabId || !changeInfo.url) return;
+    const learningUri = await getLearningUrl();
+    if (learningUri && isLearningSite(changeInfo.url, learningUri)) return;
+    stopPassiveLearning(tabId);
+  }
+
+  browser.tabs.onRemoved.addListener(onRemoved);
+  browser.tabs.onUpdated.addListener(onUpdated);
+
+  passiveLearningTabs.set(tabId, () => {
+    clearInterval(intervalRef);
+    browser.tabs.onRemoved.removeListener(onRemoved);
+    browser.tabs.onUpdated.removeListener(onUpdated);
+  });
+}
 
 export async function handleMessage(message, sender) {
   if (!message || typeof message !== 'object') {
@@ -56,8 +97,11 @@ export async function handleMessage(message, sender) {
         // was retained for content-blocker purposes only.
         const existingOrigin = await storage.origin.get();
         if (!existingOrigin || existingOrigin.tabId !== sender?.tab?.id) {
+          if (sender?.tab?.id !== undefined) startPassiveLearning(sender.tab.id);
           return { redirected: false };
         }
+        // Stop any passive tracking for this tab when full redirect session takes over 
+        stopPassiveLearning(sender?.tab?.id);
 
         // Get information on the daily goal
         const dailyGoal = parseTime.toSystem(

--- a/src/handlers/messageHandler.js
+++ b/src/handlers/messageHandler.js
@@ -52,7 +52,7 @@ export async function handleMessage(message, sender) {
     return (async () => {
       try {
         if (await SessionService.checkVoluntaryLearning(sender?.tab?.id)) {
-          SessionService.startVoluntaryLearning(sender?.tab?.id);
+          await SessionService.startVoluntaryLearning(sender?.tab?.id);
           return { redirected: false };
         }
         // Stop any voluntary tracking for this tab when full redirect session takes over

--- a/src/injection/bootstrap/learningBootstrap.js
+++ b/src/injection/bootstrap/learningBootstrap.js
@@ -21,7 +21,9 @@ export async function bootstrapLearningOverlayIfNeeded() {
     }
     let response;
     try {
-      response = await browser.runtime.sendMessage({ type: 'learning:autoStart' });
+      response = await browser.runtime.sendMessage({
+        type: 'learning:autoStart',
+      });
     } catch {}
     if (response?.redirected === false) {
       bootstrapAttemptPending = false;

--- a/src/injection/bootstrap/learningBootstrap.js
+++ b/src/injection/bootstrap/learningBootstrap.js
@@ -19,9 +19,14 @@ export async function bootstrapLearningOverlayIfNeeded() {
       bootstrapAttemptPending = false;
       return;
     }
+    let response;
     try {
-      await browser.runtime.sendMessage({ type: 'learning:autoStart' });
+      response = await browser.runtime.sendMessage({ type: 'learning:autoStart' });
     } catch {}
+    if (response?.redirected === false) {
+      bootstrapAttemptPending = false;
+      return;
+    }
     await renderLearningContent();
   } catch {
     // swallow: best-effort bootstrap.

--- a/src/injection/shared/formatters.js
+++ b/src/injection/shared/formatters.js
@@ -19,6 +19,6 @@ export const formatDuration = (value) => {
 export const formatDurationShort = (value) => {
   if (typeof value !== 'number' || value <= 0) return '0m';
   const totalSeconds = Math.floor(value / 1000);
-  const minutes = Math.ceil(totalSeconds / 60);
-  return `${minutes}m`;
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  return `${Math.ceil(totalSeconds / 60)}m`;
 };

--- a/src/redirection.js
+++ b/src/redirection.js
@@ -43,7 +43,6 @@ const redirectFlow = createRedirectFlow({
   promptControl,
   addLearningSiteLoadedListener,
   addOriginUpdatedListener,
-  removeOriginUpdatedListener,
   triggerLearningOverlay,
   getCheckActiveTab: () => checkActiveTab,
 });

--- a/src/redirection/originTracking.js
+++ b/src/redirection/originTracking.js
@@ -80,7 +80,7 @@ export function createOriginTracking({
         'tab_closed',
       );
       timer.stopLearningSession();
-      timer.stopSessionTimer();
+      timer.pauseSessionTimer();
 
       // Don't re-enable redirects if a session reward is currently active —
       // closing the origin tab while on reward time should not cancel the reward.

--- a/src/redirection/originTracking.js
+++ b/src/redirection/originTracking.js
@@ -67,16 +67,20 @@ export function createOriginTracking({
     }
 
     if (!migrated) {
-      console.log('Origin killed');
+      console.log('Learning tab closed');
       removeOriginUpdatedListener();
       promptControl.removeAllContentBlockers();
-      storage.origin.remove();
+      // Strip tabId so a direct navigation to the learning site in a new tab
+      // won't trigger the overlay, but keep origin set so the content blocker
+      // still fires if the user visits a time-wasting site.
+      storage.origin.set({ url: origin.url });
       await SessionService.finalizeSession(
         closedTabId,
         'learning',
         'tab_closed',
       );
       timer.stopLearningSession();
+      timer.stopSessionTimer();
 
       // Don't re-enable redirects if a session reward is currently active —
       // closing the origin tab while on reward time should not cancel the reward.

--- a/src/redirection/promptControl.js
+++ b/src/redirection/promptControl.js
@@ -107,6 +107,14 @@ export function createPromptControl({ navigationGuards }) {
         await setPromptCooldown(details.tabId, details.url);
         await extraCallbacks.onContinue?.();
       },
+      onReturn: async () => {
+        // User chose to return to the learning site from this tab — update
+        // origin.tabId so the overlay fires when the learning site loads.
+        const origin = await storage.origin.get();
+        if (origin) {
+          await storage.origin.set({ ...origin, tabId: details.tabId });
+        }
+      },
     });
   }
 

--- a/src/redirection/redirectFlow.js
+++ b/src/redirection/redirectFlow.js
@@ -6,7 +6,6 @@ import SessionService from '../services/SessionService';
 import { getLearningUrl } from '../services/siteDetector';
 import { checkActiveTime } from './shared/operatingHours';
 import { startRewardSession } from './shared/rewardSession';
-import { isOriginTabStillOnLearningSite } from './shared/originValidation';
 import { isTrackedTimeWastingUrl } from './shared/siteFilter';
 
 /**
@@ -25,7 +24,6 @@ import { isTrackedTimeWastingUrl } from './shared/siteFilter';
  * @param {object} deps.promptControl
  * @param {() => Promise<void>} deps.addLearningSiteLoadedListener
  * @param {() => void} deps.addOriginUpdatedListener
- * @param {() => void} deps.removeOriginUpdatedListener
  * @param {(tabId: number) => void} deps.triggerLearningOverlay
  * @param {() => Function} deps.getCheckActiveTab - Lazy getter for checkActiveTab.
  */
@@ -34,7 +32,6 @@ export function createRedirectFlow({
   promptControl,
   addLearningSiteLoadedListener,
   addOriginUpdatedListener,
-  removeOriginUpdatedListener,
   triggerLearningOverlay,
   getCheckActiveTab,
 }) {
@@ -148,22 +145,6 @@ export function createRedirectFlow({
           !timer.isSessionRewardActive()
         ) {
           console.log('ShouldRedirect', shouldRedirect);
-          const origin = await storage.origin.get();
-          console.log('Checking against this: ', origin);
-
-          // Validate that the origin learning tab still exists before showing blocker
-          if (origin && origin.tabId !== undefined) {
-            const isOriginValid = await isOriginTabStillOnLearningSite(origin);
-
-            // Clear stale origin if tab no longer exists or isn't on learning site
-            if (!isOriginValid) {
-              console.log('Origin tab no longer valid, clearing stale origin');
-              await storage.origin.remove();
-              removeOriginUpdatedListener();
-              promptControl.removeAllContentBlockers();
-              timer.stopLearningSession();
-            }
-          }
 
           const learningUri = await getLearningUrl();
           if (!learningUri) return;

--- a/src/redirection/redirectFlow.js
+++ b/src/redirection/redirectFlow.js
@@ -42,7 +42,7 @@ export function createRedirectFlow({
     addLearningSiteLoadedListener();
     navigationGuards.install();
     await SessionService.startSession(tabId, 'learning', learningUri, procUrl);
-    storage.origin.set({ url: procUrl });
+    storage.origin.set({ url: procUrl, tabId: tabId });
     addOriginUpdatedListener();
     await storage.globalPromptLock.remove();
 

--- a/src/services/PromptCoordinator.js
+++ b/src/services/PromptCoordinator.js
@@ -78,6 +78,8 @@ class PromptCoordinator {
 
         if (result?.action === 'continue' && typeof onContinue === 'function') {
           await onContinue();
+        } else if (result?.action === 'return' && typeof callbacks.onReturn === 'function') {
+          await callbacks.onReturn();
         }
 
         await this.hideImmediatePrompt(details.tabId);

--- a/src/services/PromptCoordinator.js
+++ b/src/services/PromptCoordinator.js
@@ -78,7 +78,10 @@ class PromptCoordinator {
 
         if (result?.action === 'continue' && typeof onContinue === 'function') {
           await onContinue();
-        } else if (result?.action === 'return' && typeof callbacks.onReturn === 'function') {
+        } else if (
+          result?.action === 'return' &&
+          typeof callbacks.onReturn === 'function'
+        ) {
           await callbacks.onReturn();
         }
 

--- a/src/services/SessionService.js
+++ b/src/services/SessionService.js
@@ -3,40 +3,42 @@ import browser from 'webextension-polyfill';
 import timer from './TimerManager';
 import { getLearningUrl, isLearningSite } from './siteDetector';
 
-// Voluntary learning: tracks direct-navigation learning tabs (no redirect origin)
-const voluntaryLearningTabs = new Map(); // tabId -> removeListeners
+// Voluntary learning: tracks a single direct-navigation learning tab (no redirect origin)
+let voluntaryLearningTabId = null;
+let removeVoluntaryListeners = null;
 
-function stopVoluntaryLearning(tabId) {
-  const removeListeners = voluntaryLearningTabs.get(tabId);
-  if (!removeListeners) return;
-  voluntaryLearningTabs.delete(tabId);
-  removeListeners();
-  timer.stopVoluntaryLearningTimer(tabId);
+function stopVoluntaryLearning() {
+  if (!removeVoluntaryListeners) return;
+  removeVoluntaryListeners();
+  removeVoluntaryListeners = null;
+  voluntaryLearningTabId = null;
+  timer.stopVoluntaryLearningTimer();
 }
 
 function startVoluntaryLearning(tabId) {
-  if (voluntaryLearningTabs.has(tabId)) return;
+  stopVoluntaryLearning();
 
+  voluntaryLearningTabId = tabId;
   timer.startVoluntaryLearningTimer(tabId);
 
   function onRemoved(closedTabId) {
-    if (closedTabId === tabId) stopVoluntaryLearning(tabId);
+    if (closedTabId === tabId) stopVoluntaryLearning();
   }
 
   async function onUpdated(updatedTabId, changeInfo) {
     if (updatedTabId !== tabId || !changeInfo.url) return;
     const learningUri = await getLearningUrl();
     if (learningUri && isLearningSite(changeInfo.url, learningUri)) return;
-    stopVoluntaryLearning(tabId);
+    stopVoluntaryLearning();
   }
 
   browser.tabs.onRemoved.addListener(onRemoved);
   browser.tabs.onUpdated.addListener(onUpdated);
 
-  voluntaryLearningTabs.set(tabId, () => {
+  removeVoluntaryListeners = () => {
     browser.tabs.onRemoved.removeListener(onRemoved);
     browser.tabs.onUpdated.removeListener(onUpdated);
-  });
+  };
 }
 
 // Returns true if the tab arrived via direct navigation (no redirect origin match).

--- a/src/services/SessionService.js
+++ b/src/services/SessionService.js
@@ -15,11 +15,11 @@ function stopVoluntaryLearning() {
   timer.stopVoluntaryLearningTimer();
 }
 
-function startVoluntaryLearning(tabId) {
+async function startVoluntaryLearning(tabId) {
   stopVoluntaryLearning();
 
   voluntaryLearningTabId = tabId;
-  timer.startVoluntaryLearningTimer(tabId);
+  await timer.startVoluntaryLearningTimer(tabId);
 
   function onRemoved(closedTabId) {
     if (closedTabId === tabId) stopVoluntaryLearning();

--- a/src/services/SessionService.js
+++ b/src/services/SessionService.js
@@ -39,16 +39,11 @@ function startVoluntaryLearning(tabId) {
   });
 }
 
-// Checks origin: if the tab did not arrive via a redirect, starts voluntary learning.
-// Returns true if voluntary learning was started (caller should return { redirected: false }).
-async function maybeStartVoluntaryLearning(tabId) {
+// Returns true if the tab arrived via direct navigation (no redirect origin match).
+async function checkVoluntaryLearning(tabId) {
   if (tabId === undefined) return false;
   const existingOrigin = await storage.origin.get();
-  if (!existingOrigin || existingOrigin.tabId !== tabId) {
-    startVoluntaryLearning(tabId);
-    return true;
-  }
-  return false;
+  return !existingOrigin || existingOrigin.tabId !== tabId;
 }
 
 let cachedGoalSeconds = null;
@@ -195,9 +190,9 @@ export default {
   finalizeSession,
   transferActiveSession,
   getGoalSeconds,
+  checkVoluntaryLearning,
   startVoluntaryLearning,
   stopVoluntaryLearning,
-  maybeStartVoluntaryLearning,
   logEventAsync: () => {},
   logControlledSession: async () => {},
 };

--- a/src/services/SessionService.js
+++ b/src/services/SessionService.js
@@ -1,4 +1,56 @@
 import storage from '../util/storage';
+import browser from 'webextension-polyfill';
+import timer from './TimerManager';
+import { getLearningUrl, isLearningSite } from './siteDetector';
+
+// Voluntary learning: tracks direct-navigation learning tabs (no redirect origin)
+const voluntaryLearningTabs = new Map(); // tabId -> removeListeners
+
+function stopVoluntaryLearning(tabId) {
+  const removeListeners = voluntaryLearningTabs.get(tabId);
+  if (!removeListeners) return;
+  voluntaryLearningTabs.delete(tabId);
+  removeListeners();
+  timer.stopVoluntaryLearningTimer(tabId);
+}
+
+function startVoluntaryLearning(tabId) {
+  if (voluntaryLearningTabs.has(tabId)) return;
+
+  timer.startVoluntaryLearningTimer(tabId);
+
+  function onRemoved(closedTabId) {
+    if (closedTabId === tabId) stopVoluntaryLearning(tabId);
+  }
+
+  async function onUpdated(updatedTabId, changeInfo) {
+    if (updatedTabId !== tabId || !changeInfo.url) return;
+    const learningUri = await getLearningUrl();
+    if (learningUri && isLearningSite(changeInfo.url, learningUri)) return;
+    stopVoluntaryLearning(tabId);
+  }
+
+  browser.tabs.onRemoved.addListener(onRemoved);
+  browser.tabs.onUpdated.addListener(onUpdated);
+
+  voluntaryLearningTabs.set(tabId, () => {
+    browser.tabs.onRemoved.removeListener(onRemoved);
+    browser.tabs.onUpdated.removeListener(onUpdated);
+  });
+}
+
+// Checks origin: if the tab did not arrive via a redirect, starts voluntary learning.
+// Returns true if voluntary learning was started (caller should return { redirected: false }).
+async function maybeStartVoluntaryLearning(tabId) {
+  if (tabId === undefined) return false;
+  const existingOrigin = await storage.origin.get();
+  if (!existingOrigin || existingOrigin.tabId !== tabId) {
+    startVoluntaryLearning(tabId);
+    return true;
+  }
+  return false;
+}
+
 let cachedGoalSeconds = null;
 let lastGoalFetch = 0;
 
@@ -143,6 +195,9 @@ export default {
   finalizeSession,
   transferActiveSession,
   getGoalSeconds,
+  startVoluntaryLearning,
+  stopVoluntaryLearning,
+  maybeStartVoluntaryLearning,
   logEventAsync: () => {},
   logControlledSession: async () => {},
 };

--- a/src/services/SessionService.js
+++ b/src/services/SessionService.js
@@ -42,7 +42,7 @@ async function startSession(tabId, sessionType, siteUrl, triggerUrl = null) {
   };
 
   if (sessionType === 'learning') {
-    await setOriginIfMissing(tabId);
+    if (triggerUrl) await setOriginIfMissing(tabId);
     sessionData.learningUrl = siteUrl;
     sessionData.timeWastingUrl = triggerUrl;
   } else {

--- a/src/services/SessionService.js
+++ b/src/services/SessionService.js
@@ -3,22 +3,18 @@ import browser from 'webextension-polyfill';
 import timer from './TimerManager';
 import { getLearningUrl, isLearningSite } from './siteDetector';
 
-// Voluntary learning: tracks a single direct-navigation learning tab (no redirect origin)
-let voluntaryLearningTabId = null;
 let removeVoluntaryListeners = null;
 
 function stopVoluntaryLearning() {
   if (!removeVoluntaryListeners) return;
   removeVoluntaryListeners();
   removeVoluntaryListeners = null;
-  voluntaryLearningTabId = null;
   timer.stopVoluntaryLearningTimer();
 }
 
 async function startVoluntaryLearning(tabId) {
   stopVoluntaryLearning();
 
-  voluntaryLearningTabId = tabId;
   await timer.startVoluntaryLearningTimer(tabId);
 
   function onRemoved(closedTabId) {

--- a/src/services/TimerManager.js
+++ b/src/services/TimerManager.js
@@ -228,7 +228,7 @@ class TimerManager {
     }
   }
 
-  // Stop session timer
+  // Stop session timer and clear all state
   stopSessionTimer() {
     if (this.sessionIntervalRef) {
       clearInterval(this.sessionIntervalRef);
@@ -241,9 +241,36 @@ class TimerManager {
     this.sessionOnComplete = null;
   }
 
+  // Stop the interval but preserve remaining/elapsed so the session can be resumed
+  pauseSessionTimer() {
+    if (this.sessionIntervalRef) {
+      clearInterval(this.sessionIntervalRef);
+      this.sessionIntervalRef = undefined;
+    }
+  }
+
+  // Restart the interval from the current remaining state
+  resumeSessionTimer(onComplete) {
+    if (!this.isSessionPaused()) return;
+    this.sessionOnComplete = onComplete;
+    this.sessionIntervalRef = setInterval(() => {
+      this.decrementSession().catch(() => {});
+    }, 1000);
+  }
+
   // Check if session timer is running
   isSessionActive() {
     return Boolean(this.sessionIntervalRef);
+  }
+
+  // True when a session was paused mid-progress (tab closed, not yet completed)
+  isSessionPaused() {
+    return (
+      !this.sessionIntervalRef &&
+      this.sessionGoal > 0 &&
+      this.sessionRemaining > 0 &&
+      !this.sessionCompleted
+    );
   }
 
   // Decrement session reward timer

--- a/src/services/TimerManager.js
+++ b/src/services/TimerManager.js
@@ -26,7 +26,6 @@ class TimerManager {
     this.sessionRewardOnComplete = null;
 
     this.voluntaryLearningIntervalRef = undefined;
-    this.voluntaryLearningTabId = undefined;
   }
 
   computeProgressPercent() {
@@ -165,7 +164,7 @@ class TimerManager {
   // Increments dailyProgress by one second if the relevant tab is active.
   // Returns true if active (callers can run their own logic on top).
   async tickDailyProgress(tabId = undefined) {
-    if (!await this.checkActive(tabId)) return false;
+    if (!(await this.checkActive(tabId))) return false;
     this.dailyProgress += 1000;
     await storage.dailyProgress.set(this.dailyProgress);
     return true;
@@ -173,7 +172,7 @@ class TimerManager {
 
   // Decrement session timer
   async decrementSession() {
-    if (!await this.tickDailyProgress()) return;
+    if (!(await this.tickDailyProgress())) return;
 
     this.sessionElapsed += 1000;
 
@@ -309,7 +308,6 @@ class TimerManager {
   async startVoluntaryLearningTimer(tabId) {
     this.stopVoluntaryLearningTimer();
     this.dailyProgress = await storage.dailyProgress.get();
-    this.voluntaryLearningTabId = tabId;
     this.voluntaryLearningIntervalRef = setInterval(() => {
       this.tickDailyProgress(tabId).catch(() => {});
     }, 1000);
@@ -320,7 +318,6 @@ class TimerManager {
       clearInterval(this.voluntaryLearningIntervalRef);
       this.voluntaryLearningIntervalRef = undefined;
     }
-    this.voluntaryLearningTabId = undefined;
   }
 
   getTime() {

--- a/src/services/TimerManager.js
+++ b/src/services/TimerManager.js
@@ -299,8 +299,9 @@ class TimerManager {
     return Boolean(this.sessionRewardIntervalRef);
   }
 
-  startVoluntaryLearningTimer(tabId) {
+  async startVoluntaryLearningTimer(tabId) {
     this.stopVoluntaryLearningTimer();
+    this.dailyProgress = await storage.dailyProgress.get();
     this.voluntaryLearningTabId = tabId;
     this.voluntaryLearningIntervalRef = setInterval(() => {
       this.checkActive(tabId).then((active) => {

--- a/src/services/TimerManager.js
+++ b/src/services/TimerManager.js
@@ -162,26 +162,33 @@ class TimerManager {
     };
   }
 
+  // Increments dailyProgress by one second if the relevant tab is active.
+  // Returns true if active (callers can run their own logic on top).
+  async tickDailyProgress(tabId = undefined) {
+    if (!await this.checkActive(tabId)) return false;
+    this.dailyProgress += 1000;
+    await storage.dailyProgress.set(this.dailyProgress);
+    return true;
+  }
+
   // Decrement session timer
   async decrementSession() {
-    if (await this.checkActive()) {
-      this.sessionElapsed += 1000;
+    if (!await this.tickDailyProgress()) return;
 
-      if (this.sessionRemaining > 0) {
-        this.sessionRemaining -= 1000;
-        this.dailyProgress += 1000;
-        await storage.dailyProgress.set(this.dailyProgress);
+    this.sessionElapsed += 1000;
 
-        if (this.sessionRemaining <= 0) {
-          this.sessionRemaining = 0;
+    if (this.sessionRemaining > 0) {
+      this.sessionRemaining -= 1000;
 
-          if (!this.sessionCompleted) {
-            this.sessionCompleted = true;
+      if (this.sessionRemaining <= 0) {
+        this.sessionRemaining = 0;
 
-            if (typeof this.sessionOnComplete === 'function') {
-              this.sessionOnComplete();
-              this.sessionOnComplete = null;
-            }
+        if (!this.sessionCompleted) {
+          this.sessionCompleted = true;
+
+          if (typeof this.sessionOnComplete === 'function') {
+            this.sessionOnComplete();
+            this.sessionOnComplete = null;
           }
         }
       }
@@ -304,11 +311,7 @@ class TimerManager {
     this.dailyProgress = await storage.dailyProgress.get();
     this.voluntaryLearningTabId = tabId;
     this.voluntaryLearningIntervalRef = setInterval(() => {
-      this.checkActive(tabId).then((active) => {
-        if (!active) return;
-        this.dailyProgress += 1000;
-        storage.dailyProgress.set(this.dailyProgress).catch(() => {});
-      }).catch(() => {});
+      this.tickDailyProgress(tabId).catch(() => {});
     }, 1000);
   }
 

--- a/src/services/TimerManager.js
+++ b/src/services/TimerManager.js
@@ -25,7 +25,8 @@ class TimerManager {
     this.sessionRewardElapsed = 0;
     this.sessionRewardOnComplete = null;
 
-    this.voluntaryLearningIntervals = new Map();
+    this.voluntaryLearningIntervalRef = undefined;
+    this.voluntaryLearningTabId = undefined;
   }
 
   computeProgressPercent() {
@@ -299,22 +300,23 @@ class TimerManager {
   }
 
   startVoluntaryLearningTimer(tabId) {
-    if (this.voluntaryLearningIntervals.has(tabId)) return;
-    const ref = setInterval(() => {
+    this.stopVoluntaryLearningTimer();
+    this.voluntaryLearningTabId = tabId;
+    this.voluntaryLearningIntervalRef = setInterval(() => {
       this.checkActive(tabId).then((active) => {
         if (!active) return;
         this.dailyProgress += 1000;
         storage.dailyProgress.set(this.dailyProgress).catch(() => {});
       }).catch(() => {});
     }, 1000);
-    this.voluntaryLearningIntervals.set(tabId, ref);
   }
 
-  stopVoluntaryLearningTimer(tabId) {
-    const ref = this.voluntaryLearningIntervals.get(tabId);
-    if (!ref) return;
-    clearInterval(ref);
-    this.voluntaryLearningIntervals.delete(tabId);
+  stopVoluntaryLearningTimer() {
+    if (this.voluntaryLearningIntervalRef) {
+      clearInterval(this.voluntaryLearningIntervalRef);
+      this.voluntaryLearningIntervalRef = undefined;
+    }
+    this.voluntaryLearningTabId = undefined;
   }
 
   getTime() {

--- a/src/services/TimerManager.js
+++ b/src/services/TimerManager.js
@@ -97,7 +97,7 @@ class TimerManager {
     return Boolean(this.learningTimeIntervalRef);
   }
 
-  async checkActive() {
+  async checkActive(tabId = undefined) {
     const window = await browser.windows.getCurrent();
     const views =
       typeof chrome !== 'undefined' && chrome.runtime && chrome.runtime.getViews
@@ -110,6 +110,12 @@ class TimerManager {
       });
       if (currentTabs.length > 0) {
         const current = currentTabs[0];
+
+        // Voluntary learning: just check the specific tab is active.
+        if (tabId !== undefined) {
+          return current.id === tabId;
+        }
+
         const origin = await storage.origin.get();
 
         try {
@@ -292,12 +298,14 @@ class TimerManager {
     return Boolean(this.sessionRewardIntervalRef);
   }
 
-  // Voluntary learning timer for direct-navigation tabs (no checkActive gate)
   startVoluntaryLearningTimer(tabId) {
     if (this.voluntaryLearningIntervals.has(tabId)) return;
     const ref = setInterval(() => {
-      this.dailyProgress += 1000;
-      storage.dailyProgress.set(this.dailyProgress).catch(() => {});
+      this.checkActive(tabId).then((active) => {
+        if (!active) return;
+        this.dailyProgress += 1000;
+        storage.dailyProgress.set(this.dailyProgress).catch(() => {});
+      }).catch(() => {});
     }, 1000);
     this.voluntaryLearningIntervals.set(tabId, ref);
   }

--- a/src/services/TimerManager.js
+++ b/src/services/TimerManager.js
@@ -24,6 +24,8 @@ class TimerManager {
     this.sessionRewardGoal = 0;
     this.sessionRewardElapsed = 0;
     this.sessionRewardOnComplete = null;
+
+    this.voluntaryLearningIntervals = new Map();
   }
 
   computeProgressPercent() {
@@ -288,6 +290,23 @@ class TimerManager {
   // Check if session reward timer is running
   isSessionRewardActive() {
     return Boolean(this.sessionRewardIntervalRef);
+  }
+
+  // Voluntary learning timer for direct-navigation tabs (no checkActive gate)
+  startVoluntaryLearningTimer(tabId) {
+    if (this.voluntaryLearningIntervals.has(tabId)) return;
+    const ref = setInterval(() => {
+      this.dailyProgress += 1000;
+      storage.dailyProgress.set(this.dailyProgress).catch(() => {});
+    }, 1000);
+    this.voluntaryLearningIntervals.set(tabId, ref);
+  }
+
+  stopVoluntaryLearningTimer(tabId) {
+    const ref = this.voluntaryLearningIntervals.get(tabId);
+    if (!ref) return;
+    clearInterval(ref);
+    this.voluntaryLearningIntervals.delete(tabId);
   }
 
   getTime() {

--- a/src/services/TimerManager.js
+++ b/src/services/TimerManager.js
@@ -114,24 +114,12 @@ class TimerManager {
           const learningUri = await getLearningUrl();
           const learningName = learningUri ? parseUrl(learningUri).name : '';
 
-          // Only count as active if the current tab is both the origin tab AND still on the learning host
+          // Only count time when the active tab is the redirected learning tab
+          // and it's still on the learning site.
           if (
             origin &&
             origin.tabId !== undefined &&
-            current.id === origin.tabId
-          ) {
-            if (
-              learningName &&
-              current.url &&
-              current.url.includes(learningName)
-            ) {
-              return true;
-            }
-            return false;
-          }
-
-          // Otherwise allow active if current tab is on the learning site
-          if (
+            current.id === origin.tabId &&
             learningName &&
             current.url &&
             current.url.includes(learningName)


### PR DESCRIPTION
## Problem
Navigating directly to the learning site would show the learning overlay and count time toward the daily goal, as if the user had been redirected there. This was implemented as intentional behavior at first, but has now been raised as an issue #101 by @mircealungu. An underlying issue was found afterwards, which caused the next visit to a time-wasting site to show the plain redirect prompt instead of the content blocker.

## Root causes found and fixed
1. `origin` was stored without `tabId` in `redirectFlow.js`
`storage.origin.set({ url: procUrl })` never included the tab ID, so `onOriginRemoved` could never match a closing tab, which caused origin to persist indefinitely in storage after the learning tab closed.

2. Stale-origin check in `redirect()` broke the content blocker in `redirectFlow.js`
A validation block checked `isOriginTabStillOnLearningSite` on every redirect attempt. With `tabId` now stored, this check ran on every navigation, but by the time it executed (after ~10 async storage reads), the tab had already committed to the new URL, so it always saw the time-wasting URL, falsely cleared origin, and showed the redirect prompt instead of the content blocker. The block was a workaround for the missing `tabId` and was removed.

3. Closing the learning tab killed the session in `originTracking.js`
`onOriginRemoved` cleared origin entirely on tab close, ending the session. The fix strips only the `tabId` from origin (keeping the URL), so the content blocker still fires on time-wasting sites but `learning:autoStart` rejects direct-navigation tabs that don't match the stored `tabId`.

4. "Return to learning" from content blocker didn't start the timer in `PromptCoordinator.js` and `promptControl.js`
`renderContentBlocker` had no handler for the response from clicking "Return to learning". The tab navigated to the learning site, but `origin.tabId` was undefined, so `learning:autoStart` rejected it. Fix: handle `action: 'return'` and stamp `origin.tabId` with the navigating tab before the learning site loads.

5. Session timer kept running after tab close `originTracking.js` and `TimerManager.js`
`stopLearningSession()` cleared the daily timer interval but not the session countdown. If the user then visited the learning site directly, the still-running session interval called `checkActive()`, which had a fallback that returned `true` for any tab on the learning site when `origin.tabId` was undefined. Fixed by also calling `stopSessionTimer()` on tab close and removing the fallback from `checkActive`.

6. `setOriginIfMissing` created a 'phantom origin' on direct navigation in `SessionService.js`
`maybeStartSessionForTab` triggered `startSession` without a `triggerUrl` whenever the user activated a tab on the learning site. Inside, `setOriginIfMissing` would set origin even with no redirect, causing the content blocker to appear the next time a time-wasting site was visited. Fix: only call `setOriginIfMissing` when `triggerUrl` is provided.

7. Unused `origin` variable in Popup in `Popup.svelte`
Dead `storage` import, `origin` variable, and empty `setup()` function removed.
