### PR TITLE
Refactor/overlay duplication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,7 +86,7 @@ jobs:
             --auto-publish
 
   github_release:
-    permissions: 
+    permissions:
       contents: write
     name: Create GitHub release
     needs: [publish_firefox, publish_chrome]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,9 +10,6 @@ on:
         description: 'Version tag to publish (e.g. v3.0.1) — must match package.json'
         required: true
 
-permissions:
-  contents: write
-
 env:
   PUBLIC_API_BASE_URL: https://aiki.zeeguu.dev/api/
 
@@ -87,6 +84,8 @@ jobs:
             --auto-publish
 
   github_release:
+    permissions: 
+      contents: write
     name: Create GitHub release
     needs: [publish_firefox, publish_chrome]
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,9 +22,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - id: read
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           PKG_VERSION=$(node -p "require('./package.json').version")
-          TAG="${GITHUB_REF_NAME:-${{ inputs.version }}}"
+          TAG="${GITHUB_REF_NAME:-$INPUT_VERSION}"
           TAG_VERSION="${TAG#v}"
           echo "package.json: $PKG_VERSION"
           echo "tag:          $TAG_VERSION"

--- a/src/injection/bootstrap/learningBootstrap.js
+++ b/src/injection/bootstrap/learningBootstrap.js
@@ -1,7 +1,7 @@
 import browser from 'webextension-polyfill';
 import { getLearningUrl } from '../../services/siteDetector';
 import { currentPageIsLearningSite } from '../shared/hostMatch';
-import { renderLearningContent } from '../overlays/learningPanel';
+import { renderLearningContent } from '../overlays/learningOverlay';
 
 let bootstrapAttemptPending = false;
 

--- a/src/injection/messageRouter.js
+++ b/src/injection/messageRouter.js
@@ -3,7 +3,7 @@ import { renderRedirectPrompt } from './overlays/redirectPrompt';
 import { renderLearningContent } from './overlays/learningOverlay';
 import { renderContentBlocker } from './overlays/contentBlocker';
 import { renderTimeWastingRewardOverlay } from './overlays/rewardOverlay';
-import { removeOverlay } from './shared/domHelpers';
+import { removeOverlay } from './shared/overlayHelpers';
 
 /**
  * Action keys are the strings the background script sends; some include

--- a/src/injection/messageRouter.js
+++ b/src/injection/messageRouter.js
@@ -1,6 +1,6 @@
 import browser from 'webextension-polyfill';
 import { renderRedirectPrompt } from './overlays/redirectPrompt';
-import { renderLearningContent } from './overlays/learningPanel';
+import { renderLearningContent } from './overlays/learningOverlay';
 import { renderContentBlocker } from './overlays/contentBlocker';
 import { renderTimeWastingRewardOverlay } from './overlays/rewardOverlay';
 import { removeOverlay } from './shared/domHelpers';

--- a/src/injection/overlays/contentBlocker.js
+++ b/src/injection/overlays/contentBlocker.js
@@ -1,5 +1,5 @@
 import { getLearningUrl } from '../../services/siteDetector';
-import { removeOverlay } from '../shared/domHelpers';
+import { removeOverlay } from '../shared/overlayHelpers';
 import { createTimerPort } from '../shared/timerPort';
 import { formatDuration, formatDurationShort } from '../shared/formatters';
 

--- a/src/injection/overlays/learningOverlay.js
+++ b/src/injection/overlays/learningOverlay.js
@@ -1,5 +1,5 @@
 import browser from 'webextension-polyfill';
-import { isFullScreen, removeOverlay } from '../shared/overlayHelpers';
+import { removeOverlay, createCollapseButton, watchFullscreen } from '../shared/overlayHelpers';
 import { makeDraggable } from '../shared/makeDraggable';
 import { createTimerPort } from '../shared/timerPort';
 import { formatDuration, formatDurationShort } from '../shared/formatters';
@@ -56,52 +56,12 @@ export function renderLearningContent() {
     const getPanelStyle = (collapsed) =>
       `pointer-events: auto; padding: ${collapsed ? '10px 14px' : 'clamp(16px, 3vw, 22px)'}; min-width: ${collapsed ? '140px' : '260px'}; max-width: ${collapsed ? '180px' : '320px'}; margin: 8px; background: rgba(15, 23, 42, 0.96); color: #f8fafc; border-radius: ${collapsed ? '12px' : '18px'}; box-shadow: 0 24px 45px rgba(15, 23, 42, 0.45); font-family: 'Inter', 'Segoe UI', sans-serif; display: flex; flex-direction: column; gap: ${collapsed ? '6px' : '12px'}; cursor: grab; position: relative; font-size: 14px; transition: all 0.3s ease;`;
 
-    function updateOverlayVisibility() {
-      if (isFullScreen()) {
-        // Cache position before hiding so fullscreen toggling doesn't reset
-        // the user's chosen corner.
-        panel.dataset.savedLeft = panel.style.left || '';
-        panel.dataset.savedRight = panel.style.right || '';
-        panel.dataset.savedTop = panel.style.top || '';
-        panel.dataset.savedBottom = panel.style.bottom || '';
-        overlay.style.display = 'none';
-      } else {
-        overlay.style.display = 'flex';
-        requestAnimationFrame(() => {
-          if (panel.dataset.savedLeft !== undefined) {
-            panel.style.left = panel.dataset.savedLeft;
-            panel.style.right = panel.dataset.savedRight;
-            panel.style.top = panel.dataset.savedTop;
-            panel.style.bottom = panel.dataset.savedBottom;
-          }
-        });
-      }
-    }
-
-    document.addEventListener('fullscreenchange', updateOverlayVisibility);
-    document.addEventListener(
-      'webkitfullscreenchange',
-      updateOverlayVisibility,
-    );
-    document.addEventListener('mozfullscreenchange', updateOverlayVisibility);
-    document.addEventListener('MSFullscreenChange', updateOverlayVisibility);
-
-    updateOverlayVisibility();
+    const stopWatchingFullscreen = watchFullscreen(overlay, panel);
 
     panel.setAttribute('style', getPanelStyle(isCollapsed));
 
-    const collapseBtn = document.createElement('button');
-    collapseBtn.textContent = isCollapsed ? '▼' : '▲';
-    collapseBtn.setAttribute(
-      'style',
-      'position: absolute; top: 6px; right: 8px; background: transparent; border: none; color: rgba(248, 250, 252, 0.6); cursor: pointer; font-size: 10px; padding: 4px; transition: color 0.2s;',
-    );
-    collapseBtn.addEventListener('mouseenter', () => {
-      collapseBtn.style.color = 'rgba(248, 250, 252, 0.95)';
-    });
-    collapseBtn.addEventListener('mouseleave', () => {
-      collapseBtn.style.color = 'rgba(248, 250, 252, 0.6)';
-    });
+   const collapseBtn = createCollapseButton(isCollapsed, { top: '4px', right: '6px' });
+
 
     const heading = document.createElement('strong');
     heading.textContent = '📚 Learning Session';
@@ -318,19 +278,7 @@ export function renderLearningContent() {
       try {
         removeOverlay();
       } catch {}
-      document.removeEventListener('fullscreenchange', updateOverlayVisibility);
-      document.removeEventListener(
-        'webkitfullscreenchange',
-        updateOverlayVisibility,
-      );
-      document.removeEventListener(
-        'mozfullscreenchange',
-        updateOverlayVisibility,
-      );
-      document.removeEventListener(
-        'MSFullscreenChange',
-        updateOverlayVisibility,
-      );
+      stopWatchingFullscreen();
     };
 
     overlay.cleanup = cleanup;

--- a/src/injection/overlays/learningOverlay.js
+++ b/src/injection/overlays/learningOverlay.js
@@ -1,5 +1,5 @@
 import browser from 'webextension-polyfill';
-import { removeOverlay, createCollapseButton, watchFullscreen } from '../shared/overlayHelpers';
+import { removeOverlay, createCollapseButton, watchFullscreen, applyCollapsedStyle, wireCollapseButton } from '../shared/overlayHelpers';
 import { makeDraggable } from '../shared/makeDraggable';
 import { createTimerPort } from '../shared/timerPort';
 import { formatDuration, formatDurationShort } from '../shared/formatters';
@@ -124,38 +124,15 @@ export function renderLearningContent() {
       localStorage.setItem(isCollapsedKey, isCollapsed.toString());
       collapseBtn.textContent = isCollapsed ? '▼' : '▲';
 
-      // Preserve positioning across the full style swap, otherwise the panel
-      // jumps to the default corner when the size changes.
-      const currentLeft = panel.style.left;
-      const currentTop = panel.style.top;
-      const currentPosition = panel.style.position;
-      const currentTransform = panel.style.transform;
-
-      panel.setAttribute('style', getPanelStyle(isCollapsed));
-
-      if (currentPosition) panel.style.position = currentPosition;
-      if (currentLeft) panel.style.left = currentLeft;
-      if (currentTop) panel.style.top = currentTop;
-      if (currentTransform) panel.style.transform = currentTransform;
+      applyCollapsedStyle(panel, () => panel.setAttribute('style', getPanelStyle(isCollapsed)), dragHandle);
 
       heading.style.display = isCollapsed ? 'none' : 'block';
       status.style.display = isCollapsed ? 'none' : 'block';
       barShell.style.height = isCollapsed ? '6px' : '10px';
       progressLabel.style.fontSize = isCollapsed ? '0.95em' : '0.9em';
       progressLabel.style.fontWeight = isCollapsed ? '600' : '400';
-
-      // Wait for the size transition to finish before re-snapping so the
-      // animation lands on the new dimensions.
-      setTimeout(() => {
-        if (dragHandle && dragHandle.syncIntendedPosition) {
-          dragHandle.syncIntendedPosition();
-        }
-      }, 300);
     };
-    collapseBtn.addEventListener('click', (e) => {
-      e.stopPropagation();
-      toggleCollapse();
-    });
+    wireCollapseButton(collapseBtn, toggleCollapse);
     
     
     panel.append(

--- a/src/injection/overlays/learningOverlay.js
+++ b/src/injection/overlays/learningOverlay.js
@@ -1,5 +1,5 @@
 import browser from 'webextension-polyfill';
-import { isFullScreen, removeOverlay } from '../shared/domHelpers';
+import { isFullScreen, removeOverlay } from '../shared/overlayHelpers';
 import { makeDraggable } from '../shared/makeDraggable';
 import { createTimerPort } from '../shared/timerPort';
 import { formatDuration, formatDurationShort } from '../shared/formatters';

--- a/src/injection/overlays/learningOverlay.js
+++ b/src/injection/overlays/learningOverlay.js
@@ -196,15 +196,19 @@ export function renderLearningContent() {
       e.stopPropagation();
       toggleCollapse();
     });
-
-    panel.appendChild(collapseBtn);
-    panel.appendChild(heading);
-    panel.appendChild(progressLabel);
-    panel.appendChild(barShell);
-    panel.appendChild(status);
-    panel.appendChild(claimRewardBtn);
+    
+    
+    panel.append(
+      collapseBtn,
+      heading,
+      progressLabel,
+      barShell,
+      status,
+      claimRewardBtn
+    );
     overlay.appendChild(panel);
     document.body.appendChild(overlay);
+
     installLearningOverlayPersistence();
 
     const dragHandle = makeDraggable(panel);

--- a/src/injection/overlays/learningOverlay.js
+++ b/src/injection/overlays/learningOverlay.js
@@ -1,5 +1,11 @@
 import browser from 'webextension-polyfill';
-import { removeOverlay, createCollapseButton, watchFullscreen, applyCollapsedStyle, wireCollapseButton } from '../shared/overlayHelpers';
+import {
+  removeOverlay,
+  createCollapseButton,
+  watchFullscreen,
+  applyCollapsedStyle,
+  wireCollapseButton,
+} from '../shared/overlayHelpers';
 import { makeDraggable } from '../shared/makeDraggable';
 import { createTimerPort } from '../shared/timerPort';
 import { formatDuration, formatDurationShort } from '../shared/formatters';
@@ -60,8 +66,10 @@ export function renderLearningContent() {
 
     panel.setAttribute('style', getPanelStyle(isCollapsed));
 
-   const collapseBtn = createCollapseButton(isCollapsed, { top: '4px', right: '6px' });
-
+    const collapseBtn = createCollapseButton(isCollapsed, {
+      top: '4px',
+      right: '6px',
+    });
 
     const heading = document.createElement('strong');
     heading.textContent = '📚 Learning Session';
@@ -124,7 +132,11 @@ export function renderLearningContent() {
       localStorage.setItem(isCollapsedKey, isCollapsed.toString());
       collapseBtn.textContent = isCollapsed ? '▼' : '▲';
 
-      applyCollapsedStyle(panel, () => panel.setAttribute('style', getPanelStyle(isCollapsed)), dragHandle);
+      applyCollapsedStyle(
+        panel,
+        () => panel.setAttribute('style', getPanelStyle(isCollapsed)),
+        dragHandle,
+      );
 
       heading.style.display = isCollapsed ? 'none' : 'block';
       status.style.display = isCollapsed ? 'none' : 'block';
@@ -133,15 +145,14 @@ export function renderLearningContent() {
       progressLabel.style.fontWeight = isCollapsed ? '600' : '400';
     };
     wireCollapseButton(collapseBtn, toggleCollapse);
-    
-    
+
     panel.append(
       collapseBtn,
       heading,
       progressLabel,
       barShell,
       status,
-      claimRewardBtn
+      claimRewardBtn,
     );
     overlay.appendChild(panel);
     document.body.appendChild(overlay);

--- a/src/injection/overlays/redirectPrompt.js
+++ b/src/injection/overlays/redirectPrompt.js
@@ -1,5 +1,5 @@
 import { STYLES, applyButtonHoverStyles } from '../shared/styles';
-import { removeOverlay } from '../shared/domHelpers';
+import { removeOverlay } from '../shared/overlayHelpers';
 
 /**
  * Render the modal redirect prompt asking the user whether to continue on the

--- a/src/injection/overlays/rewardOverlay.js
+++ b/src/injection/overlays/rewardOverlay.js
@@ -130,7 +130,7 @@ export function renderTimeWastingRewardOverlay() {
   };
   wireCollapseButton(collapseBtn, toggleCollapse);
 
-  panel.appendChild(collapseBtn, heading, progressLabel, barShell, status);
+  panel.append(collapseBtn, heading, progressLabel, barShell, status);
   overlay.appendChild(panel);
   document.body.appendChild(overlay);
 

--- a/src/injection/overlays/rewardOverlay.js
+++ b/src/injection/overlays/rewardOverlay.js
@@ -149,12 +149,14 @@ export function renderTimeWastingRewardOverlay() {
     e.stopPropagation();
     toggleCollapse();
   });
-
-  panel.appendChild(collapseBtn);
-  panel.appendChild(heading);
-  panel.appendChild(progressLabel);
-  panel.appendChild(barShell);
-  panel.appendChild(status);
+  
+  panel.appendChild(
+    collapseBtn,
+    heading,
+    progressLabel,
+    barShell,
+    status
+  );
   overlay.appendChild(panel);
   document.body.appendChild(overlay);
 

--- a/src/injection/overlays/rewardOverlay.js
+++ b/src/injection/overlays/rewardOverlay.js
@@ -1,6 +1,7 @@
 import browser from 'webextension-polyfill';
 import { checkCurrentPageIsTimeWastingSite } from '../shared/hostMatch';
 import { makeDraggable } from '../shared/makeDraggable';
+import { removeOverlay, createCollapseButton, watchFullscreen } from '../shared/overlayHelpers';
 import { createTimerPort } from '../shared/timerPort';
 import { formatDuration } from '../shared/formatters';
 import {
@@ -63,19 +64,13 @@ export function renderTimeWastingRewardOverlay() {
   let currentBg = 'linear-gradient(135deg, #ADD8E6, #32CD32)';
   panel.setAttribute('style', getPanelStyle(isCollapsed, currentBg));
 
-  const collapseBtn = document.createElement('button');
-  collapseBtn.textContent = isCollapsed ? '▼' : '▲';
-  collapseBtn.setAttribute(
-    'style',
-    'position: absolute; top: 4px; right: 6px; background: transparent; border: none; color: rgba(255, 255, 255, 0.6); cursor: pointer; font-size: 10px; padding: 4px; transition: color 0.2s;',
-  );
-  collapseBtn.addEventListener('mouseenter', () => {
-    collapseBtn.style.color = 'rgba(255, 255, 255, 0.95)';
-  });
-  collapseBtn.addEventListener('mouseleave', () => {
-    collapseBtn.style.color = 'rgba(255, 255, 255, 0.6)';
-  });
+  const stopWatchingFullscreen = watchFullscreen(overlay, panel);
 
+  const collapseBtn = createCollapseButton(isCollapsed, {
+    color: 'rgba(248, 250, 252, 0.6)',
+    hoverColor: 'rgba(248, 250, 252, 0.95)',
+  });
+  
   const heading = document.createElement('strong');
   heading.textContent = '🎉 Reward time';
   heading.setAttribute(
@@ -225,6 +220,7 @@ export function renderTimeWastingRewardOverlay() {
     cleanupCalled = true;
     dragHandle.cleanup();
     timerPort.cleanup();
+    stopWatchingFullscreen();
     try {
       overlay.remove();
     } catch {}

--- a/src/injection/overlays/rewardOverlay.js
+++ b/src/injection/overlays/rewardOverlay.js
@@ -1,7 +1,7 @@
 import browser from 'webextension-polyfill';
 import { checkCurrentPageIsTimeWastingSite } from '../shared/hostMatch';
 import { makeDraggable } from '../shared/makeDraggable';
-import { removeOverlay, createCollapseButton, watchFullscreen } from '../shared/overlayHelpers';
+import { removeOverlay, createCollapseButton, watchFullscreen, applyCollapsedStyle, wireCollapseButton } from '../shared/overlayHelpers';
 import { createTimerPort } from '../shared/timerPort';
 import { formatDuration } from '../shared/formatters';
 import {
@@ -110,40 +110,15 @@ export function renderTimeWastingRewardOverlay() {
     localStorage.setItem(isCollapsedKey, isCollapsed.toString());
     collapseBtn.textContent = isCollapsed ? '▼' : '▲';
 
-    // Preserve positioning across the full style swap so the panel stays in
-    // the user's chosen corner when the size changes.
-    const currentLeft = panel.style.left;
-    const currentRight = panel.style.right;
-    const currentTop = panel.style.top;
-    const currentBottom = panel.style.bottom;
-    const currentPosition = panel.style.position;
-    const currentTransform = panel.style.transform;
-
-    panel.setAttribute('style', getPanelStyle(isCollapsed, currentBg));
-
-    if (currentPosition) panel.style.position = currentPosition;
-    if (currentLeft) panel.style.left = currentLeft;
-    if (currentRight) panel.style.right = currentRight;
-    if (currentTop) panel.style.top = currentTop;
-    if (currentBottom) panel.style.bottom = currentBottom;
-    if (currentTransform) panel.style.transform = currentTransform;
+    applyCollapsedStyle(panel, () => panel.setAttribute('style', getPanelStyle(isCollapsed, currentBg)), dragHandle);
 
     heading.style.display = isCollapsed ? 'none' : 'block';
     status.style.display = isCollapsed ? 'none' : 'block';
     barShell.style.height = isCollapsed ? '5px' : '8px';
     progressLabel.style.fontSize = isCollapsed ? '0.9em' : '0.85em';
     progressLabel.style.fontWeight = isCollapsed ? '600' : '400';
-
-    setTimeout(() => {
-      if (dragHandle && dragHandle.syncIntendedPosition) {
-        dragHandle.syncIntendedPosition();
-      }
-    }, 300);
   };
-  collapseBtn.addEventListener('click', (e) => {
-    e.stopPropagation();
-    toggleCollapse();
-  });
+  wireCollapseButton(collapseBtn, toggleCollapse);
   
   panel.appendChild(
     collapseBtn,

--- a/src/injection/overlays/rewardOverlay.js
+++ b/src/injection/overlays/rewardOverlay.js
@@ -1,7 +1,13 @@
 import browser from 'webextension-polyfill';
 import { checkCurrentPageIsTimeWastingSite } from '../shared/hostMatch';
 import { makeDraggable } from '../shared/makeDraggable';
-import { removeOverlay, createCollapseButton, watchFullscreen, applyCollapsedStyle, wireCollapseButton } from '../shared/overlayHelpers';
+import {
+  removeOverlay,
+  createCollapseButton,
+  watchFullscreen,
+  applyCollapsedStyle,
+  wireCollapseButton,
+} from '../shared/overlayHelpers';
 import { createTimerPort } from '../shared/timerPort';
 import { formatDuration } from '../shared/formatters';
 import {
@@ -70,7 +76,7 @@ export function renderTimeWastingRewardOverlay() {
     color: 'rgba(248, 250, 252, 0.6)',
     hoverColor: 'rgba(248, 250, 252, 0.95)',
   });
-  
+
   const heading = document.createElement('strong');
   heading.textContent = '🎉 Reward time';
   heading.setAttribute(
@@ -110,7 +116,11 @@ export function renderTimeWastingRewardOverlay() {
     localStorage.setItem(isCollapsedKey, isCollapsed.toString());
     collapseBtn.textContent = isCollapsed ? '▼' : '▲';
 
-    applyCollapsedStyle(panel, () => panel.setAttribute('style', getPanelStyle(isCollapsed, currentBg)), dragHandle);
+    applyCollapsedStyle(
+      panel,
+      () => panel.setAttribute('style', getPanelStyle(isCollapsed, currentBg)),
+      dragHandle,
+    );
 
     heading.style.display = isCollapsed ? 'none' : 'block';
     status.style.display = isCollapsed ? 'none' : 'block';
@@ -119,14 +129,8 @@ export function renderTimeWastingRewardOverlay() {
     progressLabel.style.fontWeight = isCollapsed ? '600' : '400';
   };
   wireCollapseButton(collapseBtn, toggleCollapse);
-  
-  panel.appendChild(
-    collapseBtn,
-    heading,
-    progressLabel,
-    barShell,
-    status
-  );
+
+  panel.appendChild(collapseBtn, heading, progressLabel, barShell, status);
   overlay.appendChild(panel);
   document.body.appendChild(overlay);
 

--- a/src/injection/shared/overlayHelpers.js
+++ b/src/injection/shared/overlayHelpers.js
@@ -50,3 +50,7 @@ export function removeOverlay() {
     }
   } catch {}
 }
+
+/* Floating Overlay Helpers */
+
+/* Prompt Overlay Helpers */

--- a/src/injection/shared/overlayHelpers.js
+++ b/src/injection/shared/overlayHelpers.js
@@ -104,4 +104,27 @@ export function watchFullscreen(overlay, panel) {
   };
 }
 
+export function applyCollapsedStyle(panel, fn, dragHandle) {
+  // Preserve positioning across the full style swap, otherwise the panel
+  // jumps to the default corner when the size changes.
+  const left = panel.style.left, right = panel.style.right;
+  const top = panel.style.top, bottom = panel.style.bottom;
+  const position = panel.style.position, transform = panel.style.transform;
+  fn();
+  if (position) panel.style.position = position;
+  if (left) panel.style.left = left;
+  if (right) panel.style.right = right;
+  if (top) panel.style.top = top;
+  if (bottom) panel.style.bottom = bottom;
+  if (transform) panel.style.transform = transform;
+  setTimeout(() => dragHandle?.syncIntendedPosition?.(), 300);
+}
+
+export function wireCollapseButton(collapseBtn, toggleCollapse) {
+  collapseBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    toggleCollapse();
+  });
+}
+
 /* ----- Prompt Overlay Helpers ----- */

--- a/src/injection/shared/overlayHelpers.js
+++ b/src/injection/shared/overlayHelpers.js
@@ -52,20 +52,27 @@ export function removeOverlay() {
 }
 
 /* ----- Floating Overlay Helpers ----- */
-export function createCollapseButton(isCollapsed, {
-  color = 'rgba(255,255,255,0.6)',
-  hoverColor = 'rgba(255,255,255,0.95)',
-  top = '6px',
-  right = '8px',
-} = {}) {
+export function createCollapseButton(
+  isCollapsed,
+  {
+    color = 'rgba(255,255,255,0.6)',
+    hoverColor = 'rgba(255,255,255,0.95)',
+    top = '6px',
+    right = '8px',
+  } = {},
+) {
   const btn = document.createElement('button');
   btn.textContent = isCollapsed ? '▼' : '▲';
   btn.setAttribute(
     'style',
     `position: absolute; top: ${top}; right: ${right}; background: transparent; border: none; color: ${color}; cursor: pointer; font-size: 10px; padding: 4px; transition: color 0.2s;`,
   );
-  btn.addEventListener('mouseenter', () => { btn.style.color = hoverColor; });
-  btn.addEventListener('mouseleave', () => { btn.style.color = color; });
+  btn.addEventListener('mouseenter', () => {
+    btn.style.color = hoverColor;
+  });
+  btn.addEventListener('mouseleave', () => {
+    btn.style.color = color;
+  });
   return btn;
 }
 
@@ -107,9 +114,12 @@ export function watchFullscreen(overlay, panel) {
 export function applyCollapsedStyle(panel, fn, dragHandle) {
   // Preserve positioning across the full style swap, otherwise the panel
   // jumps to the default corner when the size changes.
-  const left = panel.style.left, right = panel.style.right;
-  const top = panel.style.top, bottom = panel.style.bottom;
-  const position = panel.style.position, transform = panel.style.transform;
+  const left = panel.style.left,
+    right = panel.style.right;
+  const top = panel.style.top,
+    bottom = panel.style.bottom;
+  const position = panel.style.position,
+    transform = panel.style.transform;
   fn();
   if (position) panel.style.position = position;
   if (left) panel.style.left = left;

--- a/src/injection/shared/overlayHelpers.js
+++ b/src/injection/shared/overlayHelpers.js
@@ -51,6 +51,57 @@ export function removeOverlay() {
   } catch {}
 }
 
-/* Floating Overlay Helpers */
+/* ----- Floating Overlay Helpers ----- */
+export function createCollapseButton(isCollapsed, {
+  color = 'rgba(255,255,255,0.6)',
+  hoverColor = 'rgba(255,255,255,0.95)',
+  top = '6px',
+  right = '8px',
+} = {}) {
+  const btn = document.createElement('button');
+  btn.textContent = isCollapsed ? '▼' : '▲';
+  btn.setAttribute(
+    'style',
+    `position: absolute; top: ${top}; right: ${right}; background: transparent; border: none; color: ${color}; cursor: pointer; font-size: 10px; padding: 4px; transition: color 0.2s;`,
+  );
+  btn.addEventListener('mouseenter', () => { btn.style.color = hoverColor; });
+  btn.addEventListener('mouseleave', () => { btn.style.color = color; });
+  return btn;
+}
 
-/* Prompt Overlay Helpers */
+export function watchFullscreen(overlay, panel) {
+  function handleChange() {
+    if (isFullScreen()) {
+      panel.dataset.savedLeft = panel.style.left || '';
+      panel.dataset.savedRight = panel.style.right || '';
+      panel.dataset.savedTop = panel.style.top || '';
+      panel.dataset.savedBottom = panel.style.bottom || '';
+      overlay.style.display = 'none';
+    } else {
+      overlay.style.display = 'flex';
+      requestAnimationFrame(() => {
+        if (panel.dataset.savedLeft !== undefined) {
+          panel.style.left = panel.dataset.savedLeft;
+          panel.style.right = panel.dataset.savedRight;
+          panel.style.top = panel.dataset.savedTop;
+          panel.style.bottom = panel.dataset.savedBottom;
+        }
+      });
+    }
+  }
+
+  document.addEventListener('fullscreenchange', handleChange);
+  document.addEventListener('webkitfullscreenchange', handleChange);
+  document.addEventListener('mozfullscreenchange', handleChange);
+  document.addEventListener('MSFullscreenChange', handleChange);
+  handleChange();
+
+  return () => {
+    document.removeEventListener('fullscreenchange', handleChange);
+    document.removeEventListener('webkitfullscreenchange', handleChange);
+    document.removeEventListener('mozfullscreenchange', handleChange);
+    document.removeEventListener('MSFullscreenChange', handleChange);
+  };
+}
+
+/* ----- Prompt Overlay Helpers ----- */


### PR DESCRIPTION
# Fix SonarCloud code duplication issues in overlay components

SonarCloud flagged a bunch of duplicated code across the overlay components so this PR tackles that.
The main fix is pulling the shared overlay logic out into its own module so the different overlays
aren't all copy-pasting the same functions.

---

## What changed and why

### New `overlayHelpers.js` module

Moved `isFullScreen` and `removeOverlay` out of `domHelpers.js` into a new file
`src/injection/shared/overlayHelpers.js`. These functions were already only used by overlay
components, so having them in `domHelpers.js` never really made sense.

Also added four new helper functions to this module:

- `createCollapseButton` - standardises how the collapse button is created across overlays.
  Before this, each overlay was building its own button with basically identical code.
- `watchFullscreen` - handles attaching the fullscreen listener. Same story, was being duplicated.
- `applyCollapsedStyle` - centralises the style preservation logic that runs when a panel
  collapses. Both overlays had their own versions of this that were doing the same thing:
  saving the panel's current position and restoring it after the size transition, so the
  panel doesn't jump around. Takes the drag handle as a parameter so it can resync the
  intended position once the transition finishes.
- `wireCollapseButton` - wires up the collapse button click handler. Previously each overlay
  had its own click handler with near-identical logic, so this just consolidates that.

All imports across the codebase have been updated to point to the new location.

### `learningPanel.js` -> `learningOverlay.js`

Renamed the file to be consistent with the naming convention used by the other overlays
(e.g. `rewardOverlay.js`). Updated it to use `createCollapseButton`, `watchFullscreen`,
`applyCollapsedStyle`, and `wireCollapseButton` from the new helpers module, which cut out
quite a bit of repeated logic.

### `rewardOverlay.js`

Same treatment as above - swapped out the duplicated collapse button, fullscreen, and style
preservation code for the new shared helpers. Passes the drag handle through to
`applyCollapsedStyle` so positioning stays consistent after collapse.

### Cleanup in `domHelpers.js`

Removed the overlay-related functions that were moved out. `domHelpers.js` should just be
for general DOM utilities, not overlay-specific stuff.

---

## Testing

Checked that both overlays still render correctly and that the collapse button, fullscreen
behaviour, and panel positioning after collapse all work the same as before. Specifically made
sure the panel doesn't jump when collapsing since that's what the `applyCollapsedStyle` change
touches. No functional changes intended, just refactoring.

---

## Security
- Publish.yml no longer grants workflow wide write permissions
- ${{ inputs.version }} is now passed through the INPUT_VERSION env var rather than being interpolated directly into the shell script. A malicious input value can no longer escape the variable context and inject commands.


---

## Notes

This was mostly mechanical refactoring so there shouldn't be any surprises, but worth keeping
an eye on the overlays during review just in case I missed an import somewhere.